### PR TITLE
Gym naming convetion

### DIFF
--- a/gym_lowcostrobot/__init__.py
+++ b/gym_lowcostrobot/__init__.py
@@ -3,31 +3,31 @@ from gymnasium.envs.registration import register
 __version__ = "0.0.1"
 
 register(
-    id="lowcostrobot-LiftCube-v0",
+    id="LiftCube-v0",
     entry_point="gym_lowcostrobot.envs:LiftCubeEnv",
     max_episode_steps=200,
 )
 
 register(
-    id="lowcostrobot-PickPlaceCube-v0",
+    id="PickPlaceCube-v0",
     entry_point="gym_lowcostrobot.envs:PickPlaceCubeEnv",
     max_episode_steps=200,
 )
 
 register(
-    id="lowcostrobot-PushCube-v0",
+    id="PushCube-v0",
     entry_point="gym_lowcostrobot.envs:PushCubeEnv",
     max_episode_steps=200,
 )
 
 register(
-    id="lowcostrobot-ReachCube-v0",
+    id="ReachCube-v0",
     entry_point="gym_lowcostrobot.envs:ReachCubeEnv",
     max_episode_steps=200,
 )
 
 register(
-    id="lowcostrobot-Stack-v0",
+    id="Stack-v0",
     entry_point="gym_lowcostrobot.envs:StackEnv",
     max_episode_steps=200,
 )


### PR DESCRIPTION
I recommend keeping the initial naming for two reasons:
- it matches the gymnasium convention for environment id (pascal case)
- having `lowcostrobot` as a prefix is somewhat the same as the namespace, which is already supported by the gym register (https://gymnasium.farama.org/api/registry/#gymnasium.register): `gym.make("gym_lowcostrobot/LiftCube-v0")`