### PR TITLE
Update readme training script args and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ ReachCube-v0:
 After defining the configuration file, you can start the training of your policy using the following command:
 
 ```sh
-python -u -m rl_zoo3.train --algo tqc --env ReachCube-v0 --gym-packages gym_lowcostrobot --conf rl_zoo3_conf.yaml --env-kwargs observation_mode:'"both"' -orga <huggingface_user> -f logs
+python -u -m rl_zoo3.train --algo tqc --env ReachCube-v0 --gym-packages gym_lowcostrobot -conf examples/rl_zoo3_conf.yaml --env-kwargs observation_mode:'"both"' -f logs
 ```
 
 - `python -u -m rl_zoo3.train`: Executes the training module from RL Zoo3.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ By leveraging these open-source tools, we believe that more individuals, researc
 To install the package, use the following command:
 
 ```bash
+pip install rl_zoo3
 pip install git+https://github.com/perezjln/gym-lowcostrobot.git
 ```
 

--- a/examples/rl_zoo3_conf.yaml
+++ b/examples/rl_zoo3_conf.yaml
@@ -25,4 +25,3 @@ ReachCube-v0:
   policy: 'MultiInputPolicy'
   frame_stack: 1  # Disable frame stacking if not needed
   use_sde: True
-  observation_mode: state


### PR DESCRIPTION
The command pip install rl_zoo3 is not included in the requirements.

Running the training command resulted in an error: rl_zoo3_conf.yaml could not be found because it is located in the examples folder.

When running the gym-lowcostrobot training command, I received an error: unexpected keyword argument 'observation_mode'.
This issue arises from the observation_mode keyword argument in the rl_zoo3_conf.yaml file for the ReachCube-V0 environment.

The argument -orga does not exist in the train script of rl_zoo3.