### PR TITLE
Adding MANIFEST.in file and updating setup.py to include the assets directory when the project is pip installed.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include gym_lowcostrobot/assets *

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,6 @@ setup(
     author="Julien Perez",
     author_email="julien.perez@epita.fr",
     packages=find_packages(),
+    include_package_data=True,
     install_requires=["gymnasium>=0.29", "mujoco>=3.0", "PyOpenGL==3.1.1a1"],
 )


### PR DESCRIPTION
Minor update to setup.py and the addition of a MANIFEST.in file. Currently if the project is pip installed via:
`pip install git+https://github.com/perezjln/gym-lowcostrobot.git`

the gym_lowcostrobot/assets directory is not copied to the installation directory resulting in the following error when attempting to use one of the included environments:
```
Traceback (most recent call last):
  File "/test/test.py", line 5, in <module>
    env = gym.make("PickPlaceCube-v0", render_mode="human")
  File "/test/venv/lib/python3.10/site-packages/gymnasium/envs/registration.py", line 802, in make
    env = env_creator(**env_spec_kwargs)
  File "/test/venv/lib/python3.10/site-packages/gym_lowcostrobot/envs/pick_place_cube_env.py", line 80, in __init__
    self.model = mujoco.MjModel.from_xml_path(os.path.join(ASSETS_PATH, "pick_place_cube.xml"), {})
ValueError: ParseXML: Error opening file '/test/venv/lib/python3.10/site-packages/gym_lowcostrobot/assets/low_cost_robot_6dof/pick_place_cube.xml': No such file or directory
```