### PR TITLE
Fix IK function, refactor code and MJCF in all environments

### DIFF
--- a/gym_lowcostrobot/__init__.py
+++ b/gym_lowcostrobot/__init__.py
@@ -5,7 +5,6 @@ from gymnasium.envs.registration import register
 __version__ = "0.0.1"
 
 ASSETS_PATH = os.path.join(os.path.dirname(__file__), "assets", "low_cost_robot_6dof")
-BASE_LINK_NAME = "link_1"
 
 register(
     id="LiftCube-v0",

--- a/gym_lowcostrobot/__init__.py
+++ b/gym_lowcostrobot/__init__.py
@@ -10,35 +10,35 @@ BASE_LINK_NAME = "link_1"
 register(
     id="LiftCube-v0",
     entry_point="gym_lowcostrobot.envs:LiftCubeEnv",
-    max_episode_steps=500,
+    max_episode_steps=50,
 )
 
 register(
     id="PickPlaceCube-v0",
     entry_point="gym_lowcostrobot.envs:PickPlaceCubeEnv",
-    max_episode_steps=500,
+    max_episode_steps=50,
 )
 
 register(
     id="PushCube-v0",
     entry_point="gym_lowcostrobot.envs:PushCubeEnv",
-    max_episode_steps=500,
+    max_episode_steps=50,
 )
 
 register(
     id="ReachCube-v0",
     entry_point="gym_lowcostrobot.envs:ReachCubeEnv",
-    max_episode_steps=500,
+    max_episode_steps=50,
 )
 
 register(
     id="StackTwoCubes-v0",
     entry_point="gym_lowcostrobot.envs:StackTwoCubesEnv",
-    max_episode_steps=500,
+    max_episode_steps=50,
 )
 
 register(
     id="PushCubeLoop-v0",
     entry_point="gym_lowcostrobot.envs:PushCubeLoopEnv",
-    max_episode_steps=500,
+    max_episode_steps=50,
 )

--- a/gym_lowcostrobot/assets/low_cost_robot_6dof/follower.xml
+++ b/gym_lowcostrobot/assets/low_cost_robot_6dof/follower.xml
@@ -1,6 +1,6 @@
 <mujoco model="follower">
   <compiler angle="radian" meshdir="./follower_meshes/"/>
-  <option integrator="implicitfast" cone="elliptic" impratio="100" timestep="0.001"/>
+  <option integrator="implicitfast" cone="elliptic" impratio="100" timestep="0.002"/>
 
   <default>
     <default class="follower">
@@ -88,6 +88,8 @@
                 <geom mesh="link_5_motor" class="visual" material="black"/>
                 <geom mesh="link_5_collision" class="finger"/>
       
+                <site name="end_effector_site" pos="-0.06429 0.00327 0.0011" quat="1 0 0 0"/>
+
                 <body name="link_6" pos="-0.01315 -0.0075 0.0145">
                   <inertial pos="-0.02507 0.0010817 -0.01414" quat="0.528148 0.5474 0.466496 0.451436" mass="0.012831" diaginertia="3.49922e-06 2.45768e-06 1.4645e-06"/>
                   <joint name="joint_6" pos="0 0 0" axis="0 0 -1" range="-2.45 0.032"/>
@@ -95,7 +97,6 @@
                   <geom mesh="link_6_collision" class="finger"/>
                 </body>
 
-                <site name="end_effector" pos="-0.06429 0.00327 0.0011"/>
               </body>
             </body>
           </body>

--- a/gym_lowcostrobot/assets/low_cost_robot_6dof/lift_cube.xml
+++ b/gym_lowcostrobot/assets/low_cost_robot_6dof/lift_cube.xml
@@ -1,37 +1,37 @@
 <mujoco model="low_cost_robot scene">
-    <!-- The timestep has a big influence on the contacts stability -->
-    <option cone="elliptic" impratio="10" timestep="0.005"/>
-  
-    <include file="follower.xml"/>
-  
-    <statistic center="0 0 0.1" extent="0.6"/>
-  
-    <visual>
-      <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
-      <rgba haze="0.15 0.25 0.35 1"/>
-      <global azimuth="150" elevation="-20" offheight="640"/>
-    </visual>
-  
-    <asset>
-      <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
-      <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
-        markrgb="0.8 0.8 0.8" width="300" height="300"/>
-      <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
-    </asset>
-  
-    <worldbody>
-      <light pos="0 0 3" dir="0 0 -1" directional="false"/>
-      <geom name="floor" size="0 0 0.05" type="plane" material="groundplane" pos="0 0 0" friction="0.1"/>
-      <body name="cube" pos="0.0 0.2 0.01">
-          <freejoint name="red_box_joint"/>
-          <inertial pos="0 0 0" mass="0.1" diaginertia="0.00016667 0.00016667 0.00016667"/>
-          <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="red_box" rgba="0.5 0 0 1" priority="1"/>
-      </body>
+  <!-- The timestep has a big influence on the contacts stability -->
+  <option cone="elliptic" impratio="10" timestep="0.002" />
 
-		<camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942"/>
-		<camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed"/>
-	  <camera name="camera_vizu" pos="-0.1 0.6 0.3" quat="-0.15 -0.1 0.6 1"/>
-	  
-    </worldbody>
-  
-  </mujoco>
+  <include file="follower.xml" />
+
+  <statistic center="0 0 0.1" extent="0.6" />
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0" />
+    <rgba haze="0.15 0.25 0.35 1" />
+    <global azimuth="150" elevation="-20" offheight="640" />
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072" />
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300" />
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2" />
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 3" dir="0 0 -1" directional="false" />
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane" pos="0 0 0" friction="0.1" />
+    <body name="cube" pos="0.0 0.2 0.01">
+      <freejoint name="red_box_joint" />
+      <inertial pos="0 0 0" mass="0.1" diaginertia="0.00016667 0.00016667 0.00016667" />
+      <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="red_box" rgba="0.5 0 0 1" priority="1" />
+    </body>
+
+    <camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942" />
+    <camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed" />
+    <camera name="camera_vizu" pos="-0.1 0.6 0.3" quat="-0.15 -0.1 0.6 1" />
+
+  </worldbody>
+
+</mujoco>

--- a/gym_lowcostrobot/assets/low_cost_robot_6dof/pick_place_cube.xml
+++ b/gym_lowcostrobot/assets/low_cost_robot_6dof/pick_place_cube.xml
@@ -1,5 +1,4 @@
 <mujoco model="low_cost_robot scene">
-	<compiler angle="radian" autolimits="true"/>
   <!-- The timestep has a big influence on the contacts stability -->
   <option cone="elliptic" impratio="10" timestep="0.002" gravity="0 0 -9.81"/>
 

--- a/gym_lowcostrobot/assets/low_cost_robot_6dof/pick_place_cube.xml
+++ b/gym_lowcostrobot/assets/low_cost_robot_6dof/pick_place_cube.xml
@@ -1,7 +1,7 @@
 <mujoco model="low_cost_robot scene">
 	<compiler angle="radian" autolimits="true" convexhull="false"/>
     <!-- The timestep has a big influence on the contacts stability -->
-    <option cone="elliptic" impratio="10" timestep="0.005" gravity="0 0 -9.81"/>
+    <option cone="elliptic" impratio="10" timestep="0.002" gravity="0 0 -9.81"/>
   
     <include file="follower.xml"/>
   
@@ -24,16 +24,16 @@
       <light pos="0 0 3" dir="0 0 -1" directional="false"/>
       <geom name="floor" size="0 0 0.05" type="plane" material="groundplane" pos="0 0 0" friction="0.1"/>
       <body name="cube" pos="0.0 0.2 0.01">
-          <freejoint name="red_box_joint"/>
-          <inertial pos="0 0 0" mass="10" diaginertia="0.00016667 0.00016667 0.00016667"/>
-          <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="red_box" rgba="0.5 0 0 1" priority="1"/>
+        <freejoint name="red_box_joint"/>
+        <inertial pos="0 0 0" mass="10" diaginertia="0.00016667 0.00016667 0.00016667"/>
+        <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="red_box" rgba="0.5 0 0 1" priority="1"/>
       </body>
 
-		<camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942"/>
-		<camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed"/>
-	  <camera name="camera_vizu" pos="-0.1 0.6 0.3" quat="-0.15 -0.1 0.6 1"/>
+		  <camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942"/>
+		  <camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed"/>
+	    <camera name="camera_vizu" pos="-0.1 0.6 0.3" quat="-0.15 -0.1 0.6 1"/>
 	  
-    <geom name="target_region" type="cylinder" pos=".06 .135 0.005" size="0.035 0.01" rgba="0 0 1 0.3"  contype="0" conaffinity="0" />
+      <geom name="target_region" type="box" pos=".06 .135 0.005" size="0.015 0.015 0.015" rgba="0 0 1 0.3"  contype="0" conaffinity="0"/>
     </worldbody>
   
   </mujoco>

--- a/gym_lowcostrobot/assets/low_cost_robot_6dof/pick_place_cube.xml
+++ b/gym_lowcostrobot/assets/low_cost_robot_6dof/pick_place_cube.xml
@@ -1,39 +1,39 @@
 <mujoco model="low_cost_robot scene">
-	<compiler angle="radian" autolimits="true" convexhull="false"/>
-    <!-- The timestep has a big influence on the contacts stability -->
-    <option cone="elliptic" impratio="10" timestep="0.002" gravity="0 0 -9.81"/>
-  
-    <include file="follower.xml"/>
-  
-    <statistic center="0 0 0.1" extent="0.6"/>
-  
-    <visual>
-      <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
-      <rgba haze="0.15 0.25 0.35 1"/>
-      <global azimuth="150" elevation="-20" offheight="640"/>
-    </visual>
-  
-    <asset>
-      <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
-      <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
-        markrgb="0.8 0.8 0.8" width="300" height="300"/>
-      <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
-    </asset>
-  
-    <worldbody>
-      <light pos="0 0 3" dir="0 0 -1" directional="false"/>
-      <geom name="floor" size="0 0 0.05" type="plane" material="groundplane" pos="0 0 0" friction="0.1"/>
-      <body name="cube" pos="0.0 0.2 0.01">
-        <freejoint name="red_box_joint"/>
-        <inertial pos="0 0 0" mass="10" diaginertia="0.00016667 0.00016667 0.00016667"/>
-        <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="red_box" rgba="0.5 0 0 1" priority="1"/>
-      </body>
+	<compiler angle="radian" autolimits="true"/>
+  <!-- The timestep has a big influence on the contacts stability -->
+  <option cone="elliptic" impratio="10" timestep="0.002" gravity="0 0 -9.81"/>
 
-		  <camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942"/>
-		  <camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed"/>
-	    <camera name="camera_vizu" pos="-0.1 0.6 0.3" quat="-0.15 -0.1 0.6 1"/>
-	  
-      <geom name="target_region" type="box" pos=".06 .135 0.005" size="0.015 0.015 0.015" rgba="0 0 1 0.3"  contype="0" conaffinity="0"/>
-    </worldbody>
+  <include file="follower.xml"/>
+
+  <statistic center="0 0 0.1" extent="0.6"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+    <global azimuth="150" elevation="-20" offheight="640"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 3" dir="0 0 -1" directional="false"/>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane" pos="0 0 0" friction="0.1"/>
+    <body name="cube" pos="0.0 0.2 0.01">
+      <freejoint name="red_box_joint"/>
+      <inertial pos="0 0 0" mass="10" diaginertia="0.00016667 0.00016667 0.00016667"/>
+      <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="red_box" rgba="0.5 0 0 1" priority="1"/>
+    </body>
+
+    <camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942"/>
+    <camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed"/>
+    <camera name="camera_vizu" pos="-0.1 0.6 0.3" quat="-0.15 -0.1 0.6 1"/>
+  
+    <geom name="target_region" type="box" pos=".06 .135 0.005" size="0.015 0.015 0.015" rgba="0 0 1 0.3"  contype="0" conaffinity="0"/>
+  </worldbody>
   
   </mujoco>

--- a/gym_lowcostrobot/assets/low_cost_robot_6dof/push_cube.xml
+++ b/gym_lowcostrobot/assets/low_cost_robot_6dof/push_cube.xml
@@ -1,6 +1,6 @@
 <mujoco model="low_cost_robot scene">
     <!-- The timestep has a big influence on the contacts stability -->
-    <option cone="elliptic" impratio="10" timestep="0.005"/>
+    <option cone="elliptic" impratio="10" timestep="0.002"/>
   
     <include file="follower.xml"/>
   
@@ -23,16 +23,16 @@
       <light pos="0 0 3" dir="0 0 -1" directional="false"/>
       <geom name="floor" size="0 0 0.05" type="plane" material="groundplane" pos="0 0 0" friction="0.1"/>
       <body name="cube" pos="0.0 0.2 0.01">
-          <freejoint name="red_box_joint"/>
-          <inertial pos="0 0 0" mass="0.1" diaginertia="0.00016667 0.00016667 0.00016667"/>
-          <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="red_box" rgba="0.5 0 0 1" priority="1"/>
+        <freejoint name="red_box_joint"/>
+        <inertial pos="0 0 0" mass="0.1" diaginertia="0.00016667 0.00016667 0.00016667"/>
+        <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="red_box" rgba="0.5 0 0 1" priority="1"/>
       </body>
 
-		<camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942"/>
-		<camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed"/>
-	  <camera name="camera_vizu" pos="-0.1 0.6 0.3" quat="-0.15 -0.1 0.6 1"/>
+      <camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942"/>
+      <camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed"/>
+      <camera name="camera_vizu" pos="-0.1 0.6 0.3" quat="-0.15 -0.1 0.6 1"/>
 
-    <geom name="target_region" type="cylinder" pos=".06 .135 0.005" size="0.035 0.01" rgba="0 0 1 0.3"  contype="0" conaffinity="0" />
+      <geom name="target_region" type="cylinder" pos=".06 .135 0.005" size="0.035 0.01" rgba="0 0 1 0.3"  contype="0" conaffinity="0" />
 	  
     </worldbody>
   

--- a/gym_lowcostrobot/assets/low_cost_robot_6dof/push_cube_loop.xml
+++ b/gym_lowcostrobot/assets/low_cost_robot_6dof/push_cube_loop.xml
@@ -1,14 +1,15 @@
 <mujoco model="bd1 scene">
-	<option timestep="0.005"/>
-    <option gravity="0 0 -9.81" />
-    
-	<compiler angle="radian" autolimits="true"/>
-    
-    <include file="follower.xml"/>
+	<option timestep="0.002" />
+	<option gravity="0 0 -9.81" />
+
+	<compiler angle="radian" autolimits="true" />
+
+	<include file="follower.xml" />
 
 	<asset>
 		<texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072" />
-		<texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3" markrgb="0.8 0.8 0.8" width="300" height="300" />
+		<texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300" />
 		<material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2" />
 	</asset>
 
@@ -21,31 +22,30 @@
 	<worldbody>
 		<light pos="0 0 3" dir="0 0 -1" directional="false" />
 		<body name="floor">
-			<geom pos="0 0 0" name="floor" size="0 0 .125" type="plane" material="groundplane" solref="0.0 0.0"/>
+			<geom pos="0 0 0" name="floor" size="0 0 .125" type="plane" material="groundplane" solref="0.0 0.0" />
 		</body>
 
 		<body name="cube" pos="0.06 0.135 0.017">
-			<freejoint name="cube"/>
-			<inertial pos="0 0 0" mass=".05" diaginertia="0.00001125 0.00001125 0.00001125"/>
-			<geom friction="1.5 1.5 1.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="cube" rgba="0.5 0 0 1" priority="1"/>
+			<freejoint name="cube" />
+			<inertial pos="0 0 0" mass=".05" diaginertia="0.00001125 0.00001125 0.00001125" />
+			<geom friction="1.5 1.5 1.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="cube" rgba="0.5 0 0 1" priority="1" />
 		</body>
 
-		<camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942"/>
-		<camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed"/>
-		<camera name="camera_vizu" pos="-0.1 0.6 0.3" quat="-0.15 -0.1 0.6 1"/>
-		
-        <!-- Goal Region 1 -->
-        <geom name="goal_region_1" type="box" pos=".06 .135 0.01" size="0.035 0.045 0.007" rgba="1 1 0 0.3"  contype="0" conaffinity="0" />
+		<camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942" />
+		<camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed" />
+		<camera name="camera_vizu" pos="-0.1 0.6 0.3" quat="-0.15 -0.1 0.6 1" />
 
-        <!-- Goal Region 2 -->
-        <geom name="goal_region_2" type="box" pos="-.06 .135 0.01" size="0.035 0.045 0.007" rgba="1 0 1 0.3"  contype="0" conaffinity="0"/>
+		<!-- Goal Region 1 -->
+		<geom name="goal_region_1" type="box" pos=".06 .135 0.01" size="0.035 0.045 0.007" rgba="1 1 0 0.3" contype="0" conaffinity="0" />
 
-        <!-- Define the rails that contain the cube -->
-        <geom name="left_wall" type="box" pos="-0.125 0.135 0.005" size="0.01 0.055 0.007" rgba="1 1 1 1" />        
-        <geom name="right_wall" type="box" pos="0.125 0.135 0.005" size="0.01 0.055 0.007" rgba="1 1 1 1" />
-        <geom name="top_wall" type="box" pos="0 0.09 0.005" size="0.125 0.01 0.007" rgba="1 1 1 1" />
-        <geom name="bottom_wall" type="box" pos="0 0.18 0.005" size="0.125 0.01 0.007" rgba="1 1 1 1" />
-   
+		<!-- Goal Region 2 -->
+		<geom name="goal_region_2" type="box" pos="-.06 .135 0.01" size="0.035 0.045 0.007" rgba="1 0 1 0.3" contype="0" conaffinity="0" />
 
-   	</worldbody>
+		<!-- Define the rails that contain the cube -->
+		<geom name="left_wall" type="box" pos="-0.125 0.135 0.005" size="0.01 0.055 0.007" rgba="1 1 1 1" />
+		<geom name="right_wall" type="box" pos="0.125 0.135 0.005" size="0.01 0.055 0.007" rgba="1 1 1 1" />
+		<geom name="top_wall" type="box" pos="0 0.09 0.005" size="0.125 0.01 0.007" rgba="1 1 1 1" />
+		<geom name="bottom_wall" type="box" pos="0 0.18 0.005" size="0.125 0.01 0.007" rgba="1 1 1 1" />
+
+	</worldbody>
 </mujoco>

--- a/gym_lowcostrobot/assets/low_cost_robot_6dof/reach_cube.xml
+++ b/gym_lowcostrobot/assets/low_cost_robot_6dof/reach_cube.xml
@@ -1,35 +1,35 @@
 <mujoco model="low_cost_robot scene">
-  	<option timestep="0.002"/>
-    <include file="follower.xml"/>
+	<option timestep="0.002" />
+	<include file="follower.xml" />
 
-    <statistic center="0 0 0.2" extent=".8"/>
-  
-    <visual>
-      <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
-      <rgba haze="0.15 0.25 0.35 1"/>
-      <global azimuth="150" elevation="-20" offheight="640"/>
-    </visual>
-  
-    <asset>
-      <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
-      <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
-        markrgb="0.8 0.8 0.8" width="300" height="300"/>
-      <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
-    </asset>
-  
-    <worldbody>
-      <light pos="0 0 3" dir="0 0 -1" directional="false"/>
-      <geom name="floor" size="0 0 0.05" type="plane" material="groundplane" pos="0 0 0" friction="0.1"/>
-      <body name="cube" pos="0.0 0.2 0.01">
-          <freejoint name="cube"/>
-          <inertial pos="0 0 0" mass="0.1" diaginertia="0.00016667 0.00016667 0.00016667"/>
-          <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="red_box" rgba="0.5 0 0 1" priority="1"/>
-      </body>
+	<statistic center="0 0 0.2" extent=".8" />
 
-      <camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942"/>
-      <camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed"/>
-      <camera name="camera_vizu" pos="-0.2 0.6 0.3" quat="-0.15 -0.1 0.6 1"/>
+	<visual>
+		<headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0" />
+		<rgba haze="0.15 0.25 0.35 1" />
+		<global azimuth="150" elevation="-20" offheight="640" />
+	</visual>
 
-    </worldbody>
-  
-  </mujoco>
+	<asset>
+		<texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072" />
+		<texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300" />
+		<material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2" />
+	</asset>
+
+	<worldbody>
+		<light pos="0 0 3" dir="0 0 -1" directional="false" />
+		<geom name="floor" size="0 0 0.05" type="plane" material="groundplane" pos="0 0 0" friction="0.1" />
+		<body name="cube" pos="0.0 0.2 0.01">
+			<freejoint name="cube" />
+			<inertial pos="0 0 0" mass="0.1" diaginertia="0.00016667 0.00016667 0.00016667" />
+			<geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="red_box" rgba="0.5 0 0 1" priority="1" />
+		</body>
+
+		<camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942" />
+		<camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed" />
+		<camera name="camera_vizu" pos="-0.2 0.6 0.3" quat="-0.15 -0.1 0.6 1" />
+
+	</worldbody>
+
+</mujoco>

--- a/gym_lowcostrobot/assets/low_cost_robot_6dof/reach_cube.xml
+++ b/gym_lowcostrobot/assets/low_cost_robot_6dof/reach_cube.xml
@@ -1,5 +1,5 @@
 <mujoco model="low_cost_robot scene">
-  	<option timestep="0.005"/>
+  	<option timestep="0.002"/>
     <include file="follower.xml"/>
 
     <statistic center="0 0 0.2" extent=".8"/>
@@ -26,8 +26,8 @@
           <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="red_box" rgba="0.5 0 0 1" priority="1"/>
       </body>
 
-		<camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942"/>
-		<camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed"/>
+      <camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942"/>
+      <camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed"/>
       <camera name="camera_vizu" pos="-0.2 0.6 0.3" quat="-0.15 -0.1 0.6 1"/>
 
     </worldbody>

--- a/gym_lowcostrobot/assets/low_cost_robot_6dof/stack_two_cubes.xml
+++ b/gym_lowcostrobot/assets/low_cost_robot_6dof/stack_two_cubes.xml
@@ -1,6 +1,6 @@
 <mujoco model="low_cost_robot scene">
     <!-- The timestep has a big influence on the contacts stability -->
-    <option cone="elliptic" impratio="10" timestep="0.005"/>
+    <option cone="elliptic" impratio="10" timestep="0.002"/>
   
     <include file="follower.xml"/>
   
@@ -22,21 +22,21 @@
     <worldbody>
       <light pos="0 0 3" dir="0 0 -1" directional="false"/>
       <geom name="floor" size="0 0 0.05" type="plane" material="groundplane" pos="0 0 0" friction="0.1"/>
-	  <body name="cube_red" pos="0.1 0.1 0.01">
-		  <freejoint name="cube_red"/>
-		  <inertial pos="0 0 0" mass="0.1" diaginertia="0.00001125 0.00001125 0.00001125"/>
-		  <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="cube_red" rgba="0.5 0 0 1" priority="1"/>
-    </body>
+      <body name="cube_red" pos="0.1 0.1 0.01">
+        <freejoint name="cube_red"/>
+        <inertial pos="0 0 0" mass="0.1" diaginertia="0.00001125 0.00001125 0.00001125"/>
+        <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="cube_red" rgba="0.5 0 0 1" priority="1"/>
+      </body>
 	
-    <body name="cube_blue" pos="-0.1 -0.1 0.01">
-	    <freejoint name="cube_blue"/>
-	    <inertial pos="0 0 0" mass="0.1" diaginertia="0.00001125 0.00001125 0.00001125"/>
-	    <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="cube_blue" rgba="0 0 0.5 1" priority="1"/>
-    </body>
+      <body name="cube_blue" pos="-0.1 -0.1 0.01">
+        <freejoint name="cube_blue"/>
+        <inertial pos="0 0 0" mass="0.1" diaginertia="0.00001125 0.00001125 0.00001125"/>
+        <geom friction="0.5" condim="4" pos="0 0 0" size="0.015 0.015 0.015" type="box" name="cube_blue" rgba="0 0 0.5 1" priority="1"/>
+      </body>
 
-		<camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942"/>
-		<camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed"/>
-	  <camera name="camera_vizu" pos="-0.1 0.6 0.3" quat="-0.15 -0.1 0.6 1"/>
+      <camera name="camera_front" pos="0.049 0.5 0.225" xyaxes="-0.998 0.056 -0.000 -0.019 -0.335 0.942"/>
+      <camera name="camera_top" pos="0 0.1 0.6" euler="0 0 0" mode="fixed"/>
+      <camera name="camera_vizu" pos="-0.1 0.6 0.3" quat="-0.15 -0.1 0.6 1"/>
 	  
     </worldbody>
   

--- a/gym_lowcostrobot/envs/lift_cube_env.py
+++ b/gym_lowcostrobot/envs/lift_cube_env.py
@@ -327,9 +327,11 @@ class LiftCubeEnv(Env):
         observation = self.get_observation()
 
         # Get the position of the cube and the distance between the end effector and the cube
+        cube_id = self.model.body("cube").id
+        cube_pos = self.data.body(cube_id).xpos.copy()
         ee_id = self.model.site("end_effector_site").id
         ee_pos = self.data.site(ee_id).xpos.copy()
-        cube_z = observation["cube_pos"][2]
+        cube_z = cube_pos[2]
 
         # info = {"is_success": self.is_success(ee_pos, observation["cube_pos"])}
         info = {}
@@ -339,7 +341,7 @@ class LiftCubeEnv(Env):
 
         # Compute the reward (dense reward)
         reward_height = cube_z - self.height_threshold
-        reward_distance = np.linalg.norm(ee_pos - observation["cube_pos"])
+        reward_distance = np.linalg.norm(ee_pos - cube_pos)
         reward = reward_height + reward_distance
         return observation, reward, terminated, truncated, info
 

--- a/gym_lowcostrobot/envs/lift_cube_env.py
+++ b/gym_lowcostrobot/envs/lift_cube_env.py
@@ -6,7 +6,7 @@ import mujoco.viewer
 import numpy as np
 from gymnasium import Env, spaces
 
-from gym_lowcostrobot import ASSETS_PATH, BASE_LINK_NAME
+from gym_lowcostrobot import ASSETS_PATH
 
 
 class LiftCubeEnv(Env):
@@ -72,19 +72,35 @@ class LiftCubeEnv(Env):
     - `render_mode (str)`: the render mode, can be "human" or "rgb_array", default is None.
     """
 
-    metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 200}
+    metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 25}
 
-    def __init__(self, observation_mode="image", action_mode="joint", render_mode=None):
+    def __init__(
+        self,
+        observation_mode="image",
+        action_mode="joint",
+        reward_type="sparse",
+        block_gripper=False,
+        distance_threshold=0.05,
+        height_threshold=0.1,
+        cube_xy_range=0.3,
+        n_substeps=20,
+        render_mode=None,
+    ):
         # Load the MuJoCo model and data
-        self.model = mujoco.MjModel.from_xml_path(os.path.join(ASSETS_PATH, "lift_cube.xml"), {})
+        self.model = mujoco.MjModel.from_xml_path(os.path.join(ASSETS_PATH, "lift_cube.xml"))
         self.data = mujoco.MjData(self.model)
 
         # Set the action space
         self.action_mode = action_mode
-        action_shape = {"joint": 6, "ee": 4}[action_mode]
+        self.block_gripper = block_gripper
+        action_shape = {"joint": 6, "ee": 3}[self.action_mode]
+        action_shape += 0 if self.block_gripper and self.action_mode == "ee" else 1
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(action_shape,), dtype=np.float32)
 
-        self.nb_dof = 6
+        self.num_dof = 6
+        self.distance_threshold = distance_threshold
+        self.height_threshold = height_threshold
+        self.reward_type = reward_type
 
         # Set the observations space
         self.observation_mode = observation_mode
@@ -100,79 +116,113 @@ class LiftCubeEnv(Env):
             observation_subspaces["cube_pos"] = spaces.Box(low=-10.0, high=10.0, shape=(3,))
         self.observation_space = gym.spaces.Dict(observation_subspaces)
 
+        self.control_decimation = n_substeps  # number of simulation steps per control step
+
         # Set the render utilities
         assert render_mode is None or render_mode in self.metadata["render_modes"]
         self.render_mode = render_mode
         if self.render_mode == "human":
-            self.viewer = mujoco.viewer.launch_passive(self.model, self.data)
-            self.viewer.cam.azimuth = -75
-            self.viewer.cam.distance = 1
+            self.viewer = mujoco.viewer.launch_passive(self.model, self.data, show_left_ui=False, show_right_ui=False)
+            self.viewer.cam.azimuth = -45.0
+            self.viewer.cam.distance = 1.5
+            self.viewer.cam.elevation = -20.0
+            self.viewer.cam.lookat = np.array([0.0, 0.0, 0.0])
         elif self.render_mode == "rgb_array":
             self.rgb_array_renderer = mujoco.Renderer(self.model, height=640, width=640)
 
         # Set additional utils
-        self.threshold_height = 0.5
-        self.cube_low = np.array([-0.15, 0.10, 0.015])
-        self.cube_high = np.array([0.15, 0.25, 0.015])
+        self.cube_xy_range = cube_xy_range
 
-        # get dof addresses
-        self.cube_dof_id = self.model.body("cube").dofadr[0]
-        self.arm_dof_id = self.model.body(BASE_LINK_NAME).dofadr[0]
-        self.arm_dof_vel_id = self.arm_dof_id
-        # if the arm is not at address 0 then the cube will have 7 states in qpos and 6 in qvel
-        if self.arm_dof_id != 0:
-            self.arm_dof_id = self.arm_dof_vel_id + 1
+        self.cube_low = np.array([-self.cube_xy_range / 2, -self.cube_xy_range / 2, 0])
+        self.cube_high = np.array([self.cube_xy_range / 2, self.cube_xy_range / 2, 0])
 
-        self.control_decimation = 4 # number of simulation steps per control step
+        # Shift in y-axis to sample from positive coordinates in the y-axis
+        self.cube_low[1] += 0.165
+        self.cube_high[1] += 0.10
 
+        # control range
+        self.ctrl_range = self.model.actuator_ctrlrange
 
-    def inverse_kinematics(self, ee_target_pos, step=0.2, joint_name="link_6", nb_dof=6, regularization=1e-6):
+    def check_joint_limits(self, q):
+        """Check if the joints is under or above its limits"""
+        for i in range(len(q)):
+            q[i] = max(self.model.jnt_range[i][0], min(q[i], self.model.jnt_range[i][1]))
+
+        return q
+
+    def inverse_kinematics(
+        self,
+        ee_target_pos,
+        ee_site="end_effector_site",
+        num_dof=6,
+        step=0.5,
+        lm_damping=0.15,
+        max_iter=10,
+        tolerance_err=0.01,
+        home_position=None,
+        nullspace_weight=0.0,
+    ):
         """
         Computes the inverse kinematics for a robotic arm to reach the target end effector position.
 
         :param ee_target_pos: numpy array of target end effector position [x, y, z]
+        :param ee_site: str, name of the end effector site
+        :param num_dof: int, number of degrees of freedom
         :param step: float, step size for the iteration
-        :param joint_name: str, name of the end effector joint
-        :param nb_dof: int, number of degrees of freedom
-        :param regularization: float, regularization factor for the pseudoinverse computation
+        :param lm_damping: float, regularization factor for the pseudoinverse computation
+        :param max_iter: int, maximum number of iterations
+        :param tolerance_err: float, tolerance error
+        :param home_position: numpy array of home joint positions to regularize towards
+        :param nullspace_weight: float, weight for the nullspace regularization
         :return: numpy array of target joint positions
         """
-        try:
-            # Get the joint ID from the name
-            joint_id = self.model.body(joint_name).id
-        except KeyError:
-            raise ValueError(f"Body name '{joint_name}' not found in the model.")
 
-        # Get the current end effector position
-        # ee_pos = self.d.geom_xpos[joint_id]
-        ee_id = self.model.body(joint_name).id
-        ee_pos = self.data.geom_xpos[ee_id]
+        if home_position is None:
+            home_position = np.zeros(num_dof)  # Default to zero if no home position is provided
 
-        # Compute the Jacobian
-        jac = np.zeros((3, self.model.nv))
-        mujoco.mj_jacBodyCom(self.model, self.data, jac, None, joint_id)
+        jacp = np.zeros((3, self.model.nv))
+        ee_id = self.model.site(ee_site).id
 
-        # Compute the difference between target and current end effector positions
-        delta_pos = ee_target_pos - ee_pos
+        # Initial joint positions
+        q = self.data.qpos[:num_dof].copy()
 
-        # Compute the pseudoinverse of the Jacobian with regularization
-        jac_reg = jac[:, :nb_dof].T @ jac[:, :nb_dof] + regularization * np.eye(nb_dof)
-        jac_pinv = np.linalg.inv(jac_reg) @ jac[:, :nb_dof].T
+        for _ in range(max_iter):
+            self.data.qpos[:num_dof] = q
+            mujoco.mj_forward(self.model, self.data)
 
-        # Compute target joint velocities
-        qdot = jac_pinv @ delta_pos
+            ee_pos = self.data.site(ee_id).xpos
+            error = ee_target_pos - ee_pos
+            error_norm = np.linalg.norm(error)
 
-        # Normalize joint velocities to avoid excessive movements
-        qdot_norm = np.linalg.norm(qdot)
-        if qdot_norm > 1.0:
-            qdot /= qdot_norm
+            # Stop iterations
+            if error_norm < tolerance_err:
+                break
 
-        # Read the current joint positions
-        qpos = self.data.qpos[self.arm_dof_id:self.arm_dof_id+nb_dof]
+            # Jacobian
+            mujoco.mj_jacSite(self.model, self.data, jacp, None, ee_id)
 
-        # Compute the new joint positions
-        q_target_pos = qpos + qdot * step
+            # Damped least squares (Levenberg-Marquardt Algorithm)
+            jac_reg = jacp[:, :num_dof].T @ jacp[:, :num_dof] + lm_damping * np.eye(num_dof)
+            jac_pinv = np.linalg.inv(jac_reg) @ jacp[:, :num_dof].T
+            qdot = jac_pinv @ error
 
+            # Nullspace control biasing joint velocities towards the home configuration
+            qdot += (np.eye(num_dof) - np.linalg.pinv(jacp[:, :num_dof]) @ jacp[:, :num_dof]) @ (
+                nullspace_weight * (home_position - self.data.qpos[:num_dof])
+            )
+
+            # Normalize joint velocity
+            qdot_norm = np.linalg.norm(qdot)
+            if qdot_norm > 1.0:
+                qdot /= qdot_norm
+
+            # Compute the new joint positions. Integrate joint velocities to obtain joint positions.
+            q += qdot * step
+
+            # Check limits
+            q = self.check_joint_limits(q)
+
+        q_target_pos = q
         return q_target_pos
 
     def apply_action(self, action):
@@ -181,23 +231,33 @@ class LiftCubeEnv(Env):
 
         Action shape
         - EE mode: [dx, dy, dz, gripper]
-        - Joint mode: [q1, q2, q3, q4, q5, q6, gripper]
+        - Joint mode: [q1, q2, q3, q4, q5, gripper]
         """
+        if np.array(action).shape != self.action_space.shape:
+            raise ValueError("Action dimension mismatch")
+        
+        action = np.clip(action, self.action_space.low, self.action_space.high)
+
         if self.action_mode == "ee":
-            # raise NotImplementedError("EE mode not implemented yet")
-            ee_action, gripper_action = action[:3], action[-1]
+            ee_action, gripper_action = action[:3], action[3]
 
             # Update the robot position based on the action
-            ee_id = self.model.body("link_6").id
-            ee_target_pos = self.data.xpos[ee_id] + ee_action
+            ee_id = self.model.site("end_effector_site").id
+            ee_target_pos = self.data.site(ee_id).xpos + ee_action * 0.05  # limit maximum change in position
+            ee_target_pos[2] = np.max((0, ee_target_pos[2]))
 
             # Use inverse kinematics to get the joint action wrt the end effector current position and displacement
             target_qpos = self.inverse_kinematics(ee_target_pos=ee_target_pos)
-            target_qpos[-1:] = gripper_action
+            
+            #Update the robot gripper position based on the action 
+            target_gripper_pos = gripper_action * 0.2
+            current_gripper_joint_angle = self.data.qpos[self.num_dof-1].copy()
+            target_qpos[-1:] = np.clip(current_gripper_joint_angle + target_gripper_pos, self.ctrl_range[-1, 0], self.ctrl_range[-1, 1])
         elif self.action_mode == "joint":
             target_low = np.array([-3.14159, -1.5708, -1.48353, -1.91986, -2.96706, -1.74533])
             target_high = np.array([3.14159, 1.22173, 1.74533, 1.91986, 2.96706, 0.0523599])
-            target_qpos = np.array(action).clip(target_low, target_high)
+            current_arm_joint_angles = self.data.qpos[: self.num_dof].copy()
+            target_qpos = np.array(action).clip(target_low, target_high) + current_arm_joint_angles
         else:
             raise ValueError("Invalid action mode, must be 'ee' or 'joint'")
 
@@ -211,11 +271,11 @@ class LiftCubeEnv(Env):
                 self.viewer.sync()
 
     def get_observation(self):
-        # qpos is [x, y, z, qw, qx, qy, qz, q1, q2, q3, q4, q5, q6, gripper]
-        # qvel is [vx, vy, vz, wx, wy, wz, dq1, dq2, dq3, dq4, dq5, dq6, dgripper]
+        # qpos is [x, y, z, qw, qx, qy, qz, q1, q2, q3, q4, q5, gripper]
+        # qvel is [vx, vy, vz, wx, wy, wz, dq1, dq2, dq3, dq4, dq5, dgripper]
         observation = {
-            "arm_qpos": self.data.qpos[self.arm_dof_id:self.arm_dof_id+self.nb_dof].astype(np.float32),
-            "arm_qvel": self.data.qvel[self.arm_dof_vel_id:self.arm_dof_vel_id+self.nb_dof].astype(np.float32),
+            "arm_qpos": self.data.qpos[: self.num_dof].astype(np.float32),
+            "arm_qvel": self.data.qvel[: self.num_dof].astype(np.float32),
         }
         if self.observation_mode in ["image", "both"]:
             self.renderer.update_scene(self.data, camera="camera_front")
@@ -223,7 +283,7 @@ class LiftCubeEnv(Env):
             self.renderer.update_scene(self.data, camera="camera_top")
             observation["image_top"] = self.renderer.render()
         if self.observation_mode in ["state", "both"]:
-            observation["cube_pos"] = self.data.qpos[self.cube_dof_id:self.cube_dof_id+3].astype(np.float32)
+            observation["cube_pos"] = self.data.qpos[self.num_dof : self.num_dof + 3].astype(np.float32)
         return observation
 
     def reset(self, seed=None, options=None):
@@ -234,8 +294,8 @@ class LiftCubeEnv(Env):
         cube_pos = self.np_random.uniform(self.cube_low, self.cube_high)
         cube_rot = np.array([1.0, 0.0, 0.0, 0.0])
         robot_qpos = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-        self.data.qpos[self.arm_dof_id:self.arm_dof_id+self.nb_dof] = robot_qpos
-        self.data.qpos[self.cube_dof_id:self.cube_dof_id+7] = np.concatenate([cube_pos, cube_rot])
+        self.data.qpos[: self.num_dof] = robot_qpos
+        self.data.qpos[self.num_dof : self.num_dof + 7] = np.concatenate([cube_pos, cube_rot])
 
         # Step the simulation
         mujoco.mj_forward(self.model, self.data)
@@ -250,17 +310,36 @@ class LiftCubeEnv(Env):
         observation = self.get_observation()
 
         # Get the position of the cube and the distance between the end effector and the cube
-        cube_pos = self.data.qpos[self.cube_dof_id:self.cube_dof_id+3]
-        cube_z = cube_pos[2]
-        ee_id = self.model.body("link_6").id
-        ee_pos = self.data.geom_xpos[ee_id]
-        ee_to_cube = np.linalg.norm(ee_pos - cube_pos)
+        ee_id = self.model.site("end_effector_site").id
+        ee_pos = self.data.site(ee_id).xpos.copy()
+        cube_z = observation["cube_pos"][2]
 
-        # Compute the reward
-        reward_height = cube_z - self.threshold_height
-        reward_distance = -ee_to_cube
+        # info = {"is_success": self.is_success(ee_pos, observation["cube_pos"])}
+        info = {}
+
+        terminated = False
+        truncated = False
+
+        # Compute the reward (dense reward)
+        reward_height = cube_z - self.height_threshold
+        reward_distance = np.linalg.norm(ee_pos - observation["cube_pos"])
         reward = reward_height + reward_distance
-        return observation, reward, False, False, {}
+        return observation, reward, terminated, truncated, info
+
+    # def goal_distance(self, goal_a, goal_b):
+    #     assert goal_a.shape == goal_b.shape
+    #     return np.linalg.norm(goal_a - goal_b)
+
+    # def is_success(self, achieved_goal, desired_goal):
+    #     d = self.goal_distance(achieved_goal, desired_goal)
+    #     return d < self.distance_threshold
+
+    # def compute_reward(self, achieved_goal, desired_goal):
+    #     d = self.goal_distance(achieved_goal, desired_goal)
+    #     if self.reward_type == "sparse":
+    #         return -(d > self.distance_threshold).astype(np.float32)
+    #     else:
+    #         return -d
 
     def render(self):
         if self.render_mode == "human":

--- a/gym_lowcostrobot/envs/lift_cube_env.py
+++ b/gym_lowcostrobot/envs/lift_cube_env.py
@@ -93,8 +93,8 @@ class LiftCubeEnv(Env):
         # Set the action space
         self.action_mode = action_mode
         self.block_gripper = block_gripper
-        action_shape = {"joint": 6, "ee": 3}[self.action_mode]
-        action_shape += 0 if self.block_gripper and self.action_mode == "ee" else 1
+        action_shape = {"joint": 5, "ee": 3}[self.action_mode]
+        action_shape += 0 if self.block_gripper else 1
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(action_shape,), dtype=np.float32)
 
         self.num_dof = 6
@@ -258,8 +258,23 @@ class LiftCubeEnv(Env):
         elif self.action_mode == "joint":
             target_low = np.array([-3.14159, -1.5708, -1.48353, -1.91986, -2.96706, -1.74533])
             target_high = np.array([3.14159, 1.22173, 1.74533, 1.91986, 2.96706, 0.0523599])
-            current_arm_joint_angles = self.data.qpos[: self.num_dof].copy()
-            target_qpos = np.array(action).clip(target_low, target_high) + current_arm_joint_angles
+            # Separate arm joint angles and gripper position
+            current_joint_angles = self.data.qpos[: self.num_dof].copy()
+            arm_action = np.array(action[: self.num_dof - 1])
+            gripper_action = action[-1]
+
+            # Clip and update arm joint positions
+            target_arm_qpos = np.clip(
+                arm_action + current_joint_angles[: self.num_dof - 1],
+                target_low[: self.num_dof - 1],
+                target_high[: self.num_dof - 1],
+            )
+
+            # Clip and update gripper position
+            target_gripper_pos = np.clip(gripper_action + current_joint_angles[-1], target_low[-1], target_high[-1])
+
+            # Combine arm and gripper targets
+            target_qpos = np.append(target_arm_qpos, target_gripper_pos)
         else:
             raise ValueError("Invalid action mode, must be 'ee' or 'joint'")
 

--- a/gym_lowcostrobot/envs/lift_cube_env.py
+++ b/gym_lowcostrobot/envs/lift_cube_env.py
@@ -235,7 +235,7 @@ class LiftCubeEnv(Env):
         """
         if np.array(action).shape != self.action_space.shape:
             raise ValueError("Action dimension mismatch")
-        
+
         action = np.clip(action, self.action_space.low, self.action_space.high)
 
         if self.action_mode == "ee":
@@ -248,11 +248,13 @@ class LiftCubeEnv(Env):
 
             # Use inverse kinematics to get the joint action wrt the end effector current position and displacement
             target_qpos = self.inverse_kinematics(ee_target_pos=ee_target_pos)
-            
-            #Update the robot gripper position based on the action 
+
+            # Update the robot gripper position based on the action
             target_gripper_pos = gripper_action * 0.2
-            current_gripper_joint_angle = self.data.qpos[self.num_dof-1].copy()
-            target_qpos[-1:] = np.clip(current_gripper_joint_angle + target_gripper_pos, self.ctrl_range[-1, 0], self.ctrl_range[-1, 1])
+            current_gripper_joint_angle = self.data.qpos[self.num_dof - 1].copy()
+            target_qpos[-1:] = np.clip(
+                current_gripper_joint_angle + target_gripper_pos, self.ctrl_range[-1, 0], self.ctrl_range[-1, 1]
+            )
         elif self.action_mode == "joint":
             target_low = np.array([-3.14159, -1.5708, -1.48353, -1.91986, -2.96706, -1.74533])
             target_high = np.array([3.14159, 1.22173, 1.74533, 1.91986, 2.96706, 0.0523599])

--- a/gym_lowcostrobot/envs/pick_place_cube_env.py
+++ b/gym_lowcostrobot/envs/pick_place_cube_env.py
@@ -152,7 +152,6 @@ class PickPlaceCubeEnv(Env):
         # control range
         self.ctrl_range = self.model.actuator_ctrlrange
 
-
     def check_joint_limits(self, q):
         """Check if the joints is under or above its limits"""
         for i in range(len(q)):
@@ -245,7 +244,7 @@ class PickPlaceCubeEnv(Env):
         """
         if np.array(action).shape != self.action_space.shape:
             raise ValueError("Action dimension mismatch")
-        
+
         action = np.clip(action, self.action_space.low, self.action_space.high)
 
         if self.action_mode == "ee":
@@ -258,11 +257,13 @@ class PickPlaceCubeEnv(Env):
 
             # Use inverse kinematics to get the joint action wrt the end effector current position and displacement
             target_qpos = self.inverse_kinematics(ee_target_pos=ee_target_pos)
-            
-            #Update the robot gripper position based on the action 
+
+            # Update the robot gripper position based on the action
             target_gripper_pos = gripper_action * 0.2
-            current_gripper_joint_angle = self.data.qpos[self.num_dof-1].copy()
-            target_qpos[-1:] = np.clip(current_gripper_joint_angle + target_gripper_pos, self.ctrl_range[-1, 0], self.ctrl_range[-1, 1])
+            current_gripper_joint_angle = self.data.qpos[self.num_dof - 1].copy()
+            target_qpos[-1:] = np.clip(
+                current_gripper_joint_angle + target_gripper_pos, self.ctrl_range[-1, 0], self.ctrl_range[-1, 1]
+            )
         elif self.action_mode == "joint":
             target_low = np.array([-3.14159, -1.5708, -1.48353, -1.91986, -2.96706, -1.74533])
             target_high = np.array([3.14159, 1.22173, 1.74533, 1.91986, 2.96706, 0.0523599])

--- a/gym_lowcostrobot/envs/pick_place_cube_env.py
+++ b/gym_lowcostrobot/envs/pick_place_cube_env.py
@@ -81,7 +81,7 @@ class PickPlaceCubeEnv(Env):
         observation_mode="image",
         action_mode="joint",
         reward_type="sparse",
-        block_gripper=True,
+        block_gripper=False,
         distance_threshold=0.05,
         cube_xy_range=0.3,
         target_xy_range=0.3,

--- a/gym_lowcostrobot/envs/pick_place_cube_env.py
+++ b/gym_lowcostrobot/envs/pick_place_cube_env.py
@@ -342,11 +342,15 @@ class PickPlaceCubeEnv(Env):
         # Get the new observation
         observation = self.get_observation()
 
-        info = {"is_success": self.is_success(observation["cube_pos"], observation["target_pos"])}
+        # Get the position of the cube 
+        cube_id = self.model.body("cube").id
+        cube_pos = self.data.body(cube_id).xpos.copy()
+
+        info = {"is_success": self.is_success(cube_pos, observation["target_pos"])}
 
         terminated = info["is_success"]
         truncated = False
-        reward = self.compute_reward(observation["cube_pos"], observation["target_pos"])
+        reward = self.compute_reward(cube_pos, observation["target_pos"])
         return observation, reward, terminated, truncated, info
 
     def goal_distance(self, goal_a, goal_b):

--- a/gym_lowcostrobot/envs/push_cube_env.py
+++ b/gym_lowcostrobot/envs/push_cube_env.py
@@ -6,14 +6,14 @@ import mujoco.viewer
 import numpy as np
 from gymnasium import Env, spaces
 
-from gym_lowcostrobot import ASSETS_PATH, BASE_LINK_NAME
+from gym_lowcostrobot import ASSETS_PATH
 
 
 class PushCubeEnv(Env):
     """
     ## Description
 
-    The robot has to push a cube with its end-effector.
+    The robot has to push a cube with its end-effector to a target position in the floor.
 
     ## Action space
 
@@ -63,7 +63,8 @@ class PushCubeEnv(Env):
 
     ## Reward
 
-    The reward is the negative distance between the cube and the target position.
+    For a dense reward type, it is the negative distance between the target position and the cube.
+    For a sparse reward type, it is -1 when the distance between the target position and the cube exceeds a specified distance_threshold.
 
     ## Arguments
 
@@ -73,19 +74,34 @@ class PushCubeEnv(Env):
     - `render_mode (str)`: the render mode, can be "human" or "rgb_array", default is None.
     """
 
-    metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 200}
+    metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 25}
 
-    def __init__(self, observation_mode="image", action_mode="joint", render_mode=None):
+    def __init__(
+        self,
+        observation_mode="image",
+        action_mode="joint",
+        reward_type="sparse",
+        block_gripper=True,
+        distance_threshold=0.05,
+        cube_xy_range=0.3,
+        target_xy_range=0.3,
+        n_substeps=20,
+        render_mode=None,
+    ):
         # Load the MuJoCo model and data
-        self.model = mujoco.MjModel.from_xml_path(os.path.join(ASSETS_PATH, "push_cube.xml"), {})
+        self.model = mujoco.MjModel.from_xml_path(os.path.join(ASSETS_PATH, "push_cube.xml"))
         self.data = mujoco.MjData(self.model)
 
         # Set the action space
         self.action_mode = action_mode
-        action_shape = {"joint": 6, "ee": 4}[action_mode]
+        self.block_gripper = block_gripper
+        action_shape = {"joint": 6, "ee": 3}[self.action_mode]
+        action_shape += 0 if self.block_gripper and self.action_mode == "ee" else 1
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(action_shape,), dtype=np.float32)
- 
-        self.nb_dof = 6
+
+        self.num_dof = 6
+        self.distance_threshold = distance_threshold
+        self.reward_type = reward_type
 
         # Set the observations space
         self.observation_mode = observation_mode
@@ -102,80 +118,115 @@ class PushCubeEnv(Env):
             observation_subspaces["cube_pos"] = spaces.Box(low=-10.0, high=10.0, shape=(3,))
         self.observation_space = gym.spaces.Dict(observation_subspaces)
 
+        self.control_decimation = n_substeps  # number of simulation steps per control step
+
         # Set the render utilities
         assert render_mode is None or render_mode in self.metadata["render_modes"]
         self.render_mode = render_mode
         if self.render_mode == "human":
-            self.viewer = mujoco.viewer.launch_passive(self.model, self.data)
-            self.viewer.cam.azimuth = -75
-            self.viewer.cam.distance = 1
+            self.viewer = mujoco.viewer.launch_passive(self.model, self.data, show_left_ui=False, show_right_ui=False)
+            self.viewer.cam.azimuth = -45.0
+            self.viewer.cam.distance = 1.5
+            self.viewer.cam.elevation = -20.0
+            self.viewer.cam.lookat = np.array([0.0, 0.0, 0.0])
         elif self.render_mode == "rgb_array":
             self.rgb_array_renderer = mujoco.Renderer(self.model, height=640, width=640)
 
         # Set additional utils
-        self.threshold_height = 0.5
-        self.cube_low = np.array([-0.15, 0.10, 0.015])
-        self.cube_high = np.array([0.15, 0.25, 0.015])
-        self.target_low = np.array([-0.15, 0.10, 0.005])
-        self.target_high = np.array([0.15, 0.25, 0.005])
+        self.cube_xy_range = cube_xy_range
+        self.target_xy_range = target_xy_range
 
-        # get dof addresses
-        self.cube_dof_id = self.model.body("cube").dofadr[0]
-        self.arm_dof_id = self.model.body(BASE_LINK_NAME).dofadr[0]
-        self.arm_dof_vel_id = self.arm_dof_id
-        # if the arm is not at address 0 then the cube will have 7 states in qpos and 6 in qvel
-        if self.arm_dof_id != 0:
-            self.arm_dof_id = self.arm_dof_vel_id + 1
+        self.cube_low = np.array([-self.cube_xy_range / 2, -self.cube_xy_range / 2, 0])
+        self.cube_high = np.array([self.cube_xy_range / 2, self.cube_xy_range / 2, 0])
+        self.target_low = np.array([-self.target_xy_range / 2, -self.target_xy_range / 2, 0])
+        self.target_high = np.array([self.target_xy_range / 2, self.target_xy_range / 2, 0])
 
-        self.control_decimation = 4 # number of simulation steps per control step
+        # Shift in y-axis to sample from positive coordinates in the y-axis
+        self.cube_low[1] += 0.165
+        self.cube_high[1] += 0.10
+        self.target_low[1] += 0.165
+        self.target_high[1] += 0.10
 
-    def inverse_kinematics(self, ee_target_pos, step=0.2, joint_name="link_6", nb_dof=6, regularization=1e-6):
+    def check_joint_limits(self, q):
+        """Check if the joints is under or above its limits"""
+        for i in range(len(q)):
+            q[i] = max(self.model.jnt_range[i][0], min(q[i], self.model.jnt_range[i][1]))
+
+        return q
+
+    def inverse_kinematics(
+        self,
+        ee_target_pos,
+        ee_site="end_effector_site",
+        num_dof=6,
+        step=0.5,
+        lm_damping=0.15,
+        max_iter=10,
+        tolerance_err=0.01,
+        home_position=None,
+        nullspace_weight=0.0,
+    ):
         """
         Computes the inverse kinematics for a robotic arm to reach the target end effector position.
 
         :param ee_target_pos: numpy array of target end effector position [x, y, z]
+        :param ee_site: str, name of the end effector site
+        :param num_dof: int, number of degrees of freedom
         :param step: float, step size for the iteration
-        :param joint_name: str, name of the end effector joint
-        :param nb_dof: int, number of degrees of freedom
-        :param regularization: float, regularization factor for the pseudoinverse computation
+        :param lm_damping: float, regularization factor for the pseudoinverse computation
+        :param max_iter: int, maximum number of iterations
+        :param tolerance_err: float, tolerance error
+        :param home_position: numpy array of home joint positions to regularize towards
+        :param nullspace_weight: float, weight for the nullspace regularization
         :return: numpy array of target joint positions
         """
-        try:
-            # Get the joint ID from the name
-            joint_id = self.model.body(joint_name).id
-        except KeyError:
-            raise ValueError(f"Body name '{joint_name}' not found in the model.")
 
-        # Get the current end effector position
-        # ee_pos = self.d.geom_xpos[joint_id]
-        ee_id = self.model.body(joint_name).id
-        ee_pos = self.data.geom_xpos[ee_id]
+        if home_position is None:
+            home_position = np.zeros(num_dof)  # Default to zero if no home position is provided
 
-        # Compute the Jacobian
-        jac = np.zeros((3, self.model.nv))
-        mujoco.mj_jacBodyCom(self.model, self.data, jac, None, joint_id)
+        jacp = np.zeros((3, self.model.nv))
+        ee_id = self.model.site(ee_site).id
 
-        # Compute the difference between target and current end effector positions
-        delta_pos = ee_target_pos - ee_pos
+        # Initial joint positions
+        q = self.data.qpos[:num_dof].copy()
 
-        # Compute the pseudoinverse of the Jacobian with regularization
-        jac_reg = jac[:, :nb_dof].T @ jac[:, :nb_dof] + regularization * np.eye(nb_dof)
-        jac_pinv = np.linalg.inv(jac_reg) @ jac[:, :nb_dof].T
+        for _ in range(max_iter):
+            self.data.qpos[:num_dof] = q
+            mujoco.mj_forward(self.model, self.data)
 
-        # Compute target joint velocities
-        qdot = jac_pinv @ delta_pos
+            ee_pos = self.data.site(ee_id).xpos
+            error = ee_target_pos - ee_pos
+            error_norm = np.linalg.norm(error)
 
-        # Normalize joint velocities to avoid excessive movements
-        qdot_norm = np.linalg.norm(qdot)
-        if qdot_norm > 1.0:
-            qdot /= qdot_norm
+            # Stop iterations
+            if error_norm < tolerance_err:
+                break
 
-        # Read the current joint positions
-        qpos = self.data.qpos[self.arm_dof_id:self.arm_dof_id+nb_dof]
+            # Jacobian
+            mujoco.mj_jacSite(self.model, self.data, jacp, None, ee_id)
 
-        # Compute the new joint positions
-        q_target_pos = qpos + qdot * step
+            # Damped least squares (Levenberg-Marquardt Algorithm)
+            jac_reg = jacp[:, :num_dof].T @ jacp[:, :num_dof] + lm_damping * np.eye(num_dof)
+            jac_pinv = np.linalg.inv(jac_reg) @ jacp[:, :num_dof].T
+            qdot = jac_pinv @ error
 
+            # Nullspace control biasing joint velocities towards the home configuration
+            qdot += (np.eye(num_dof) - np.linalg.pinv(jacp[:, :num_dof]) @ jacp[:, :num_dof]) @ (
+                nullspace_weight * (home_position - self.data.qpos[:num_dof])
+            )
+
+            # Normalize joint velocity
+            qdot_norm = np.linalg.norm(qdot)
+            if qdot_norm > 1.0:
+                qdot /= qdot_norm
+
+            # Compute the new joint positions. Integrate joint velocities to obtain joint positions.
+            q += qdot * step
+
+            # Check limits
+            q = self.check_joint_limits(q)
+
+        q_target_pos = q
         return q_target_pos
 
     def apply_action(self, action):
@@ -184,23 +235,33 @@ class PushCubeEnv(Env):
 
         Action shape
         - EE mode: [dx, dy, dz, gripper]
-        - Joint mode: [q1, q2, q3, q4, q5, q6, gripper]
+        - Joint mode: [q1, q2, q3, q4, q5, gripper]
         """
+
+        if np.array(action).shape != self.action_space.shape:
+            raise ValueError("Action dimension mismatch")
+
+        action = np.clip(action, self.action_space.low, self.action_space.high)
+
         if self.action_mode == "ee":
-            # raise NotImplementedError("EE mode not implemented yet")
-            ee_action, gripper_action = action[:3], action[-1]
+            ee_action = action[:3]
 
             # Update the robot position based on the action
-            ee_id = self.model.body("link_6").id
-            ee_target_pos = self.data.xpos[ee_id] + ee_action
+            ee_id = self.model.site("end_effector_site").id
+            ee_target_pos = self.data.site(ee_id).xpos + ee_action * 0.05  # limit maximum change in position
+            ee_target_pos[2] = np.max((0, ee_target_pos[2]))
 
             # Use inverse kinematics to get the joint action wrt the end effector current position and displacement
             target_qpos = self.inverse_kinematics(ee_target_pos=ee_target_pos)
-            target_qpos[-1:] = gripper_action
+            # Block the gripper for push task
+            target_qpos[-1:] = np.array([0])
         elif self.action_mode == "joint":
             target_low = np.array([-3.14159, -1.5708, -1.48353, -1.91986, -2.96706, -1.74533])
             target_high = np.array([3.14159, 1.22173, 1.74533, 1.91986, 2.96706, 0.0523599])
-            target_qpos = np.array(action).clip(target_low, target_high)
+            current_arm_joint_angles = self.data.qpos[: self.num_dof].copy()
+            target_qpos = np.array(action).clip(target_low, target_high) + current_arm_joint_angles
+            # Block the gripper for push task
+            target_qpos[-1:] = np.array([0])
         else:
             raise ValueError("Invalid action mode, must be 'ee' or 'joint'")
 
@@ -213,13 +274,12 @@ class PushCubeEnv(Env):
             if self.render_mode == "human":
                 self.viewer.sync()
 
-
     def get_observation(self):
-        # qpos is [x, y, z, qw, qx, qy, qz, q1, q2, q3, q4, q5, q6, gripper]
-        # qvel is [vx, vy, vz, wx, wy, wz, dq1, dq2, dq3, dq4, dq5, dq6, dgripper]
+        # qpos is [x, y, z, qw, qx, qy, qz, q1, q2, q3, q4, q5, gripper]
+        # qvel is [vx, vy, vz, wx, wy, wz, dq1, dq2, dq3, dq4, dq5, dgripper]
         observation = {
-            "arm_qpos": self.data.qpos[self.arm_dof_id:self.arm_dof_id+self.nb_dof].astype(np.float32),
-            "arm_qvel": self.data.qvel[self.arm_dof_vel_id:self.arm_dof_vel_id+self.nb_dof].astype(np.float32),
+            "arm_qpos": self.data.qpos[: self.num_dof].astype(np.float32),
+            "arm_qvel": self.data.qvel[: self.num_dof].astype(np.float32),
             "target_pos": self.target_pos,
         }
         if self.observation_mode in ["image", "both"]:
@@ -228,7 +288,7 @@ class PushCubeEnv(Env):
             self.renderer.update_scene(self.data, camera="camera_top")
             observation["image_top"] = self.renderer.render()
         if self.observation_mode in ["state", "both"]:
-            observation["cube_pos"] = self.data.qpos[self.cube_dof_id:self.cube_dof_id+3].astype(np.float32)
+            observation["cube_pos"] = self.data.qpos[self.num_dof : self.num_dof + 3].astype(np.float32).copy()
         return observation
 
     def reset(self, seed=None, options=None):
@@ -239,14 +299,14 @@ class PushCubeEnv(Env):
         cube_pos = self.np_random.uniform(self.cube_low, self.cube_high)
         cube_rot = np.array([1.0, 0.0, 0.0, 0.0])
         robot_qpos = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-        self.data.qpos[self.arm_dof_id:self.arm_dof_id+self.nb_dof] = robot_qpos
-        self.data.qpos[self.cube_dof_id:self.cube_dof_id+7] = np.concatenate([cube_pos, cube_rot])
+        self.data.qpos[: self.num_dof] = robot_qpos
+        self.data.qpos[self.num_dof : self.num_dof + 7] = np.concatenate([cube_pos, cube_rot])
 
         # Sample the target position
         self.target_pos = self.np_random.uniform(self.target_low, self.target_high).astype(np.float32)
 
-        # update visualization
-        self.model.geom('target_region').pos = self.target_pos[:]
+        # Update visualization
+        self.model.geom("target_region").pos = self.target_pos[:]
 
         # Step the simulation
         mujoco.mj_forward(self.model, self.data)
@@ -260,13 +320,27 @@ class PushCubeEnv(Env):
         # Get the new observation
         observation = self.get_observation()
 
-        # Get the position of the cube and the distance between the end effector and the cube
-        cube_pos = self.data.qpos[self.cube_dof_id:self.cube_dof_id+3]
-        cube_to_target = np.linalg.norm(cube_pos - self.target_pos)
+        info = {"is_success": self.is_success(observation["cube_pos"], observation["target_pos"])}
 
-        # Compute the reward
-        reward = -cube_to_target
-        return observation, reward, False, False, {}
+        terminated = info["is_success"]
+        truncated = False
+        reward = self.compute_reward(observation["cube_pos"], observation["target_pos"])
+        return observation, reward, terminated, truncated, info
+
+    def goal_distance(self, goal_a, goal_b):
+        assert goal_a.shape == goal_b.shape
+        return np.linalg.norm(goal_a - goal_b, axis=-1)
+
+    def is_success(self, achieved_goal, desired_goal):
+        d = self.goal_distance(achieved_goal, desired_goal)
+        return d < self.distance_threshold
+
+    def compute_reward(self, achieved_goal, desired_goal, info=None):
+        d = self.goal_distance(achieved_goal, desired_goal)
+        if self.reward_type == "sparse":
+            return -(d > self.distance_threshold).astype(np.float32)
+        else:
+            return -d
 
     def render(self):
         if self.render_mode == "human":

--- a/gym_lowcostrobot/envs/push_cube_env.py
+++ b/gym_lowcostrobot/envs/push_cube_env.py
@@ -334,11 +334,15 @@ class PushCubeEnv(Env):
         # Get the new observation
         observation = self.get_observation()
 
-        info = {"is_success": self.is_success(observation["cube_pos"], observation["target_pos"])}
+        # Get the position of the cube
+        cube_id = self.model.body("cube").id
+        cube_pos = self.data.body(cube_id).xpos.copy()
+
+        info = {"is_success": self.is_success(cube_pos, observation["target_pos"])}
 
         terminated = info["is_success"]
         truncated = False
-        reward = self.compute_reward(observation["cube_pos"], observation["target_pos"])
+        reward = self.compute_reward(cube_pos, observation["target_pos"])
         return observation, reward, terminated, truncated, info
 
     def goal_distance(self, goal_a, goal_b):

--- a/gym_lowcostrobot/envs/push_cube_env.py
+++ b/gym_lowcostrobot/envs/push_cube_env.py
@@ -95,8 +95,8 @@ class PushCubeEnv(Env):
         # Set the action space
         self.action_mode = action_mode
         self.block_gripper = block_gripper
-        action_shape = {"joint": 6, "ee": 3}[self.action_mode]
-        action_shape += 0 if self.block_gripper and self.action_mode == "ee" else 1
+        action_shape = {"joint": 5, "ee": 3}[self.action_mode]
+        action_shape += 0 if self.block_gripper else 1
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(action_shape,), dtype=np.float32)
 
         self.num_dof = 6
@@ -258,10 +258,24 @@ class PushCubeEnv(Env):
         elif self.action_mode == "joint":
             target_low = np.array([-3.14159, -1.5708, -1.48353, -1.91986, -2.96706, -1.74533])
             target_high = np.array([3.14159, 1.22173, 1.74533, 1.91986, 2.96706, 0.0523599])
-            current_arm_joint_angles = self.data.qpos[: self.num_dof].copy()
-            target_qpos = np.array(action).clip(target_low, target_high) + current_arm_joint_angles
+            # Separate arm joint angles and gripper position
+            current_joint_angles = self.data.qpos[: self.num_dof].copy()
+            arm_action = np.array(action[: self.num_dof - 1])
             # Block the gripper for push task
-            target_qpos[-1:] = np.array([0])
+            gripper_action = np.array([0])
+
+            # Clip and update arm joint positions
+            target_arm_qpos = np.clip(
+                arm_action + current_joint_angles[: self.num_dof - 1],
+                target_low[: self.num_dof - 1],
+                target_high[: self.num_dof - 1],
+            )
+
+            # Clip and update gripper position
+            target_gripper_pos = gripper_action
+
+            # Combine arm and gripper targets
+            target_qpos = np.append(target_arm_qpos, target_gripper_pos)
         else:
             raise ValueError("Invalid action mode, must be 'ee' or 'joint'")
 

--- a/gym_lowcostrobot/envs/push_cube_loop_env.py
+++ b/gym_lowcostrobot/envs/push_cube_loop_env.py
@@ -89,8 +89,8 @@ class PushCubeLoopEnv(Env):
         # Set the action space
         self.action_mode = action_mode
         self.block_gripper = block_gripper
-        action_shape = {"joint": 6, "ee": 3}[self.action_mode]
-        action_shape += 0 if self.block_gripper and self.action_mode == "ee" else 1
+        action_shape = {"joint": 5, "ee": 3}[self.action_mode]
+        action_shape += 0 if self.block_gripper else 1
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(action_shape,), dtype=np.float32)
 
         self.num_dof = 6
@@ -250,10 +250,24 @@ class PushCubeLoopEnv(Env):
         elif self.action_mode == "joint":
             target_low = np.array([-3.14159, -1.5708, -1.48353, -1.91986, -2.96706, -1.74533])
             target_high = np.array([3.14159, 1.22173, 1.74533, 1.91986, 2.96706, 0.0523599])
-            current_arm_joint_angles = self.data.qpos[: self.num_dof].copy()
-            target_qpos = np.array(action).clip(target_low, target_high) + current_arm_joint_angles
+            # Separate arm joint angles and gripper position
+            current_joint_angles = self.data.qpos[: self.num_dof].copy()
+            arm_action = np.array(action[: self.num_dof - 1])
             # Block the gripper for push task
-            target_qpos[-1:] = np.array([0])
+            gripper_action = np.array([0])
+
+            # Clip and update arm joint positions
+            target_arm_qpos = np.clip(
+                arm_action + current_joint_angles[: self.num_dof - 1],
+                target_low[: self.num_dof - 1],
+                target_high[: self.num_dof - 1],
+            )
+
+            # Clip and update gripper position
+            target_gripper_pos = gripper_action
+
+            # Combine arm and gripper targets
+            target_qpos = np.append(target_arm_qpos, target_gripper_pos)
         else:
             raise ValueError("Invalid action mode, must be 'ee' or 'joint'")
 

--- a/gym_lowcostrobot/envs/push_cube_loop_env.py
+++ b/gym_lowcostrobot/envs/push_cube_loop_env.py
@@ -78,11 +78,7 @@ class PushCubeLoopEnv(Env):
         self,
         observation_mode="image",
         action_mode="joint",
-        reward_type="sparse",
         block_gripper=True,
-        distance_threshold=0.05,
-        cube_xy_range=0.3,
-        target_xy_range=0.3,
         n_substeps=20,
         render_mode=None,
     ):
@@ -98,8 +94,6 @@ class PushCubeLoopEnv(Env):
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(action_shape,), dtype=np.float32)
 
         self.num_dof = 6
-        self.distance_threshold = distance_threshold
-        self.reward_type = reward_type
 
         # Set the observations space
         self.observation_mode = observation_mode
@@ -127,22 +121,7 @@ class PushCubeLoopEnv(Env):
         elif self.render_mode == "rgb_array":
             self.rgb_array_renderer = mujoco.Renderer(self.model, height=640, width=640)
 
-        # Set additional utils
-        # self.threshold_height = 0.5
-        # self.nb_dof = 6
-
-        # # get dof addresses
-        # self.cube_dof_id = self.model.body("cube").dofadr[0]
-        # self.arm_dof_id = self.model.body(BASE_LINK_NAME).dofadr[0]
-        # self.arm_dof_vel_id = self.arm_dof_id
-        # # if the arm is not at address 0 then the cube will have 7 states in qpos and 6 in qvel
-        # if self.arm_dof_id != 0:
-        #     self.arm_dof_id = self.arm_dof_vel_id + 1
-
-        self.cube_low = np.array([-0.15, 0.10, 0.015])
-        self.cube_high = np.array([0.15, 0.25, 0.015])
-
-        self.cube_size = 0.015
+        self.cube_size = 0.015 / 2
         self.cube_position = np.array([0.0, 0.0, 0.0])
 
         goal_region_1_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_GEOM, "goal_region_1")
@@ -151,7 +130,7 @@ class PushCubeLoopEnv(Env):
         self.goal_region_1_center = self.model.geom_pos[goal_region_1_id]
         self.goal_region_2_center = self.model.geom_pos[goal_region_2_id]
 
-        self.goal_region_high = self.model.geom_size[goal_region_1_id]
+        self.goal_region_high = self.model.geom_size[goal_region_1_id] / 2
         self.goal_region_high[:2] -= 0.008  # offset sampling region to keep cube within
         self.goal_region_low = self.goal_region_high * np.array([-1.0, -1.0, 1.0])
         self.current_goal = 0  # 0 for first goal region , and 1 for second goal region

--- a/gym_lowcostrobot/envs/reach_cube_env.py
+++ b/gym_lowcostrobot/envs/reach_cube_env.py
@@ -6,7 +6,7 @@ import mujoco.viewer
 import numpy as np
 from gymnasium import Env, spaces
 
-from gym_lowcostrobot import ASSETS_PATH, BASE_LINK_NAME
+from gym_lowcostrobot import ASSETS_PATH
 
 
 class ReachCubeEnv(Env):
@@ -61,8 +61,8 @@ class ReachCubeEnv(Env):
 
     ## Reward
 
-    The reward is the sum of two terms: the height of the cube above the threshold and the negative distance between the
-    end effector and the cube.
+    For a dense reward type, it is the negative distance between the end effector and the cube.
+    For a sparse reward type, it is -1 when the distance between the end effector and the cube exceeds a specified distance_threshold.
 
     ## Arguments
 
@@ -72,19 +72,33 @@ class ReachCubeEnv(Env):
     - `render_mode (str)`: the render mode, can be "human" or "rgb_array", default is None.
     """
 
-    metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 200}
+    metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 25}
 
-    def __init__(self, observation_mode="image", action_mode="joint", render_mode=None):
+    def __init__(
+        self,
+        observation_mode="image",
+        action_mode="joint",
+        reward_type="sparse",
+        block_gripper=True,
+        distance_threshold=0.05,
+        cube_xy_range=0.3,
+        n_substeps=20,
+        render_mode=None,
+    ):
         # Load the MuJoCo model and data
-        self.model = mujoco.MjModel.from_xml_path(os.path.join(ASSETS_PATH, "reach_cube.xml"), {})
+        self.model = mujoco.MjModel.from_xml_path(os.path.join(ASSETS_PATH, "reach_cube.xml"))
         self.data = mujoco.MjData(self.model)
 
         # Set the action space
         self.action_mode = action_mode
-        action_shape = {"joint": 6, "ee": 4}[action_mode]
+        self.block_gripper = block_gripper
+        action_shape = {"joint": 6, "ee": 3}[self.action_mode]
+        action_shape += 0 if self.block_gripper and self.action_mode == "ee" else 1
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(action_shape,), dtype=np.float32)
 
-        self.nb_dof = 6
+        self.num_dof = 6
+        self.distance_threshold = distance_threshold
+        self.reward_type = reward_type
 
         # Set the observations space
         self.observation_mode = observation_mode
@@ -100,93 +114,110 @@ class ReachCubeEnv(Env):
             observation_subspaces["cube_pos"] = spaces.Box(low=-10.0, high=10.0, shape=(3,))
         self.observation_space = gym.spaces.Dict(observation_subspaces)
 
-        self.control_decimation = 4 # number of simulation steps per control step
+        self.control_decimation = n_substeps  # number of simulation steps per control step
 
         # Set the render utilities
         assert render_mode is None or render_mode in self.metadata["render_modes"]
         self.render_mode = render_mode
         if self.render_mode == "human":
-            self.viewer = mujoco.viewer.launch_passive(self.model, self.data)
-            self.viewer.cam.azimuth = -75
-            self.viewer.cam.distance = 1
+            self.viewer = mujoco.viewer.launch_passive(self.model, self.data, show_left_ui=False, show_right_ui=False)
+            self.viewer.cam.azimuth = -45.0
+            self.viewer.cam.distance = 1.5
+            self.viewer.cam.elevation = -20.0
+            self.viewer.cam.lookat = np.array([0.0, 0.0, 0.0])
         elif self.render_mode == "rgb_array":
             self.rgb_array_renderer = mujoco.Renderer(self.model, height=640, width=640)
 
         # Set additional utils
-        self.threshold_height = 0.5
-        self.cube_low = np.array([-0.15, 0.10, 0.015])
-        self.cube_high = np.array([0.15, 0.25, 0.015])
+        self.cube_xy_range = cube_xy_range
 
-        # get dof addresses
-        self.cube_dof_id = self.model.body("cube").dofadr[0]
-        self.arm_dof_id = self.model.body(BASE_LINK_NAME).dofadr[0]
-        self.arm_dof_vel_id = self.arm_dof_id
-        # if the arm is not at address 0 then the cube will have 7 states in qpos and 6 in qvel
-        if self.arm_dof_id != 0:
-            self.arm_dof_id = self.arm_dof_vel_id + 1
+        self.cube_low = np.array([-self.cube_xy_range / 2, -self.cube_xy_range / 2, 0])
+        self.cube_high = np.array([self.cube_xy_range / 2, self.cube_xy_range / 2, 0])
+
+        # Shift in y-axis to sample from positive coordinates in the y-axis
+        self.cube_low[1] += 0.165
+        self.cube_high[1] += 0.10
+
+    def check_joint_limits(self, q):
+        """Check if the joints is under or above its limits"""
+        for i in range(len(q)):
+            q[i] = max(self.model.jnt_range[i][0], min(q[i], self.model.jnt_range[i][1]))
+
+        return q
 
     def inverse_kinematics(
         self,
         ee_target_pos,
-        step=0.2,
-        joint_name="link_6",
-        nb_dof=6,
-        regularization=1e-6,
+        ee_site="end_effector_site",
+        num_dof=6,
+        step=0.5,
+        lm_damping=0.15,
+        max_iter=10,
+        tolerance_err=0.01,
         home_position=None,
-        nullspace_weight=0.1,
+        nullspace_weight=0.0,
     ):
         """
         Computes the inverse kinematics for a robotic arm to reach the target end effector position.
 
         :param ee_target_pos: numpy array of target end effector position [x, y, z]
+        :param ee_site: str, name of the end effector site
+        :param num_dof: int, number of degrees of freedom
         :param step: float, step size for the iteration
-        :param joint_name: str, name of the end effector joint
-        :param nb_dof: int, number of degrees of freedom
-        :param regularization: float, regularization factor for the pseudoinverse computation
+        :param lm_damping: float, regularization factor for the pseudoinverse computation
+        :param max_iter: int, maximum number of iterations
+        :param tolerance_err: float, tolerance error
         :param home_position: numpy array of home joint positions to regularize towards
         :param nullspace_weight: float, weight for the nullspace regularization
         :return: numpy array of target joint positions
         """
+
         if home_position is None:
-            home_position = np.zeros(nb_dof)  # Default to zero if no home position is provided
+            home_position = np.zeros(num_dof)  # Default to zero if no home position is provided
 
-        try:
-            # Get the joint ID from the name
-            joint_id = self.model.body(joint_name).id
-        except KeyError:
-            raise ValueError(f"Body name '{joint_name}' not found in the model.")
+        jacp = np.zeros((3, self.model.nv))
+        ee_id = self.model.site(ee_site).id
 
-        # Get the current end effector position
-        ee_id = self.model.body(joint_name).id
-        ee_pos = self.data.geom_xpos[ee_id]
+        # Initial joint positions
+        q = self.data.qpos[:num_dof].copy()
 
-        # Compute the Jacobian
-        jac = np.zeros((3, self.model.nv))
-        mujoco.mj_jacBodyCom(self.model, self.data, jac, None, joint_id)
+        for _ in range(max_iter):
+            self.data.qpos[:num_dof] = q
+            mujoco.mj_forward(self.model, self.data)
 
-        # Compute the difference between target and current end effector positions
-        delta_pos = ee_target_pos - ee_pos
+            ee_pos = self.data.site(ee_id).xpos
+            error = ee_target_pos - ee_pos
+            error_norm = np.linalg.norm(error)
 
-        # Compute the pseudoinverse of the Jacobian with regularization
-        jac_reg = jac[:, :nb_dof].T @ jac[:, :nb_dof] + regularization * np.eye(nb_dof)
-        jac_pinv = np.linalg.inv(jac_reg) @ jac[:, :nb_dof].T
+            # Stop iterations
+            if error_norm < tolerance_err:
+                break
 
-        # Compute target joint velocities
-        qdot = jac_pinv @ delta_pos
+            # Jacobian
+            mujoco.mj_jacSite(self.model, self.data, jacp, None, ee_id)
 
-        # Add nullspace regularization to keep joint positions close to the home position
-        qpos = self.data.qpos[self.arm_dof_id:self.arm_dof_id+nb_dof]
-        nullspace_reg = nullspace_weight * (home_position - qpos)
-        qdot += nullspace_reg
+            # Damped least squares (Levenberg-Marquardt Algorithm)
+            jac_reg = jacp[:, :num_dof].T @ jacp[:, :num_dof] + lm_damping * np.eye(num_dof)
+            jac_pinv = np.linalg.inv(jac_reg) @ jacp[:, :num_dof].T
+            qdot = jac_pinv @ error
 
-        # Normalize joint velocities to avoid excessive movements
-        qdot_norm = np.linalg.norm(qdot)
-        if qdot_norm > 1.0:
-            qdot /= qdot_norm
+            # Nullspace control biasing joint velocities towards the home configuration
+            qdot += (np.eye(num_dof) - np.linalg.pinv(jacp[:, :num_dof]) @ jacp[:, :num_dof]) @ (
+                nullspace_weight * (home_position - self.data.qpos[:num_dof])
+            )
 
-        # Compute the new joint positions
-        q_target_pos = qpos + qdot * step
+            # Normalize joint velocity
+            qdot_norm = np.linalg.norm(qdot)
+            if qdot_norm > 1.0:
+                qdot /= qdot_norm
 
+            # Compute the new joint positions. Integrate joint velocities to obtain joint positions.
+            q += qdot * step
+
+            # Check limits
+            q = self.check_joint_limits(q)
+
+        q_target_pos = q
         return q_target_pos
 
     def apply_action(self, action):
@@ -195,23 +226,27 @@ class ReachCubeEnv(Env):
 
         Action shape
         - EE mode: [dx, dy, dz, gripper]
-        - Joint mode: [q1, q2, q3, q4, q5, q6, gripper]
+        - Joint mode: [q1, q2, q3, q4, q5, gripper]
         """
         if self.action_mode == "ee":
-            # raise NotImplementedError("EE mode not implemented yet")
-            ee_action, gripper_action = action[:3], action[-1]
+            ee_action = action[:3]
 
             # Update the robot position based on the action
-            ee_id = self.model.body("link_6").id
-            ee_target_pos = self.data.xpos[ee_id] + ee_action
+            ee_id = self.model.site("end_effector_site").id
+            ee_target_pos = self.data.site(ee_id).xpos + ee_action * 0.05  # limit maximum change in position
+            ee_target_pos[2] = np.max((0, ee_target_pos[2]))
 
             # Use inverse kinematics to get the joint action wrt the end effector current position and displacement
             target_qpos = self.inverse_kinematics(ee_target_pos=ee_target_pos)
-            target_qpos[-1:] = gripper_action
+            # Block the gripper for reach task
+            target_qpos[-1:] = np.array([0])
         elif self.action_mode == "joint":
             target_low = np.array([-3.14159, -1.5708, -1.48353, -1.91986, -2.96706, -1.74533])
             target_high = np.array([3.14159, 1.22173, 1.74533, 1.91986, 2.96706, 0.0523599])
-            target_qpos = np.array(action).clip(target_low, target_high)
+            current_arm_joint_angles = self.data.qpos[: self.num_dof].copy()
+            target_qpos = np.array(action).clip(target_low, target_high) + current_arm_joint_angles
+            # Block the gripper for reach task
+            target_qpos[-1:] = np.array([0])
         else:
             raise ValueError("Invalid action mode, must be 'ee' or 'joint'")
 
@@ -225,11 +260,11 @@ class ReachCubeEnv(Env):
                 self.viewer.sync()
 
     def get_observation(self):
-        # qpos is [x, y, z, qw, qx, qy, qz, q1, q2, q3, q4, q5, q6, gripper]
-        # qvel is [vx, vy, vz, wx, wy, wz, dq1, dq2, dq3, dq4, dq5, dq6, dgripper]
+        # qpos is [x, y, z, qw, qx, qy, qz, q1, q2, q3, q4, q5, gripper]
+        # qvel is [vx, vy, vz, wx, wy, wz, dq1, dq2, dq3, dq4, dq5, dgripper]
         observation = {
-            "arm_qpos": self.data.qpos[self.arm_dof_id:self.arm_dof_id+self.nb_dof].astype(np.float32),
-            "arm_qvel": self.data.qvel[self.arm_dof_vel_id:self.arm_dof_vel_id+self.nb_dof].astype(np.float32),
+            "arm_qpos": self.data.qpos[: self.num_dof].astype(np.float32),
+            "arm_qvel": self.data.qvel[: self.num_dof].astype(np.float32),
         }
         if self.observation_mode in ["image", "both"]:
             self.renderer.update_scene(self.data, camera="camera_front")
@@ -237,7 +272,7 @@ class ReachCubeEnv(Env):
             self.renderer.update_scene(self.data, camera="camera_top")
             observation["image_top"] = self.renderer.render()
         if self.observation_mode in ["state", "both"]:
-            observation["cube_pos"] = self.data.qpos[self.cube_dof_id:self.cube_dof_id+3].astype(np.float32)
+            observation["cube_pos"] = self.data.qpos[self.num_dof : self.num_dof + 3].astype(np.float32)
         return observation
 
     def reset(self, seed=None, options=None):
@@ -248,8 +283,8 @@ class ReachCubeEnv(Env):
         cube_pos = self.np_random.uniform(self.cube_low, self.cube_high)
         cube_rot = np.array([1.0, 0.0, 0.0, 0.0])
         robot_qpos = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-        self.data.qpos[self.arm_dof_id:self.arm_dof_id+self.nb_dof] = robot_qpos
-        self.data.qpos[self.cube_dof_id:self.cube_dof_id+7] = np.concatenate([cube_pos, cube_rot])
+        self.data.qpos[: self.num_dof] = robot_qpos
+        self.data.qpos[self.num_dof : self.num_dof + 7] = np.concatenate([cube_pos, cube_rot])
 
         # Step the simulation
         mujoco.mj_forward(self.model, self.data)
@@ -264,13 +299,33 @@ class ReachCubeEnv(Env):
         observation = self.get_observation()
 
         # Get the position of the cube and the distance between the end effector and the cube
-        cube_pos = self.data.xpos[2]
-        ee_pos = self.data.xpos[8]
-        ee_to_cube = np.linalg.norm(ee_pos - cube_pos)
+        cube_id = self.model.body("cube").id
+        cube_pos = self.data.xpos[cube_id]
 
-        # Compute the reward
-        reward = -ee_to_cube
-        return observation, reward, False, False, {}
+        ee_id = self.model.site("end_effector_site").id
+        ee_pos = self.data.site(ee_id).xpos
+
+        info = {"is_success": self.is_success(ee_pos, cube_pos)}
+
+        terminated = info["is_success"]
+        truncated = False
+        reward = self.compute_reward(ee_pos, cube_pos)
+        return observation, reward, terminated, truncated, info
+
+    def goal_distance(self, goal_a, goal_b):
+        assert goal_a.shape == goal_b.shape
+        return np.linalg.norm(goal_a - goal_b)
+
+    def is_success(self, achieved_goal, desired_goal):
+        d = self.goal_distance(achieved_goal, desired_goal)
+        return d < self.distance_threshold
+
+    def compute_reward(self, achieved_goal, desired_goal):
+        d = self.goal_distance(achieved_goal, desired_goal)
+        if self.reward_type == "sparse":
+            return -(d > self.distance_threshold).astype(np.float32)
+        else:
+            return -d
 
     def render(self):
         if self.render_mode == "human":

--- a/gym_lowcostrobot/envs/reach_cube_env.py
+++ b/gym_lowcostrobot/envs/reach_cube_env.py
@@ -230,9 +230,9 @@ class ReachCubeEnv(Env):
         """
         if np.array(action).shape != self.action_space.shape:
             raise ValueError("Action dimension mismatch")
-        
+
         action = np.clip(action, self.action_space.low, self.action_space.high)
-        
+
         if self.action_mode == "ee":
             ee_action = action[:3]
 

--- a/gym_lowcostrobot/envs/reach_cube_env.py
+++ b/gym_lowcostrobot/envs/reach_cube_env.py
@@ -92,8 +92,8 @@ class ReachCubeEnv(Env):
         # Set the action space
         self.action_mode = action_mode
         self.block_gripper = block_gripper
-        action_shape = {"joint": 6, "ee": 3}[self.action_mode]
-        action_shape += 0 if self.block_gripper and self.action_mode == "ee" else 1
+        action_shape = {"joint": 5, "ee": 3}[self.action_mode]
+        action_shape += 0 if self.block_gripper else 1
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(action_shape,), dtype=np.float32)
 
         self.num_dof = 6
@@ -248,10 +248,24 @@ class ReachCubeEnv(Env):
         elif self.action_mode == "joint":
             target_low = np.array([-3.14159, -1.5708, -1.48353, -1.91986, -2.96706, -1.74533])
             target_high = np.array([3.14159, 1.22173, 1.74533, 1.91986, 2.96706, 0.0523599])
-            current_arm_joint_angles = self.data.qpos[: self.num_dof].copy()
-            target_qpos = np.array(action).clip(target_low, target_high) + current_arm_joint_angles
-            # Block the gripper for reach task
-            target_qpos[-1:] = np.array([0])
+            # Separate arm joint angles and gripper position
+            current_joint_angles = self.data.qpos[: self.num_dof].copy()
+            arm_action = np.array(action[: self.num_dof - 1])
+            # Block the gripper for push task
+            gripper_action = np.array([0])
+
+            # Clip and update arm joint positions
+            target_arm_qpos = np.clip(
+                arm_action + current_joint_angles[: self.num_dof - 1],
+                target_low[: self.num_dof - 1],
+                target_high[: self.num_dof - 1],
+            )
+
+            # Clip and update gripper position
+            target_gripper_pos = gripper_action
+
+            # Combine arm and gripper targets
+            target_qpos = np.append(target_arm_qpos, target_gripper_pos)
         else:
             raise ValueError("Invalid action mode, must be 'ee' or 'joint'")
 

--- a/gym_lowcostrobot/envs/reach_cube_env.py
+++ b/gym_lowcostrobot/envs/reach_cube_env.py
@@ -304,17 +304,14 @@ class ReachCubeEnv(Env):
         observation = self.get_observation()
 
         # Get the position of the cube and the distance between the end effector and the cube
-        cube_id = self.model.body("cube").id
-        cube_pos = self.data.xpos[cube_id]
-
         ee_id = self.model.site("end_effector_site").id
-        ee_pos = self.data.site(ee_id).xpos
+        ee_pos = self.data.site(ee_id).xpos.copy()
 
-        info = {"is_success": self.is_success(ee_pos, cube_pos)}
+        info = {"is_success": self.is_success(ee_pos, observation["cube_pos"])}
 
         terminated = info["is_success"]
         truncated = False
-        reward = self.compute_reward(ee_pos, cube_pos)
+        reward = self.compute_reward(ee_pos, observation["cube_pos"])
         return observation, reward, terminated, truncated, info
 
     def goal_distance(self, goal_a, goal_b):

--- a/gym_lowcostrobot/envs/reach_cube_env.py
+++ b/gym_lowcostrobot/envs/reach_cube_env.py
@@ -228,6 +228,11 @@ class ReachCubeEnv(Env):
         - EE mode: [dx, dy, dz, gripper]
         - Joint mode: [q1, q2, q3, q4, q5, gripper]
         """
+        if np.array(action).shape != self.action_space.shape:
+            raise ValueError("Action dimension mismatch")
+        
+        action = np.clip(action, self.action_space.low, self.action_space.high)
+        
         if self.action_mode == "ee":
             ee_action = action[:3]
 

--- a/gym_lowcostrobot/envs/reach_cube_env.py
+++ b/gym_lowcostrobot/envs/reach_cube_env.py
@@ -317,15 +317,19 @@ class ReachCubeEnv(Env):
         # Get the new observation
         observation = self.get_observation()
 
+        # Get the position of the cube
+        cube_id = self.model.body("cube").id
+        cube_pos = self.data.body(cube_id).xpos.copy()
+
         # Get the position of the cube and the distance between the end effector and the cube
         ee_id = self.model.site("end_effector_site").id
         ee_pos = self.data.site(ee_id).xpos.copy()
 
-        info = {"is_success": self.is_success(ee_pos, observation["cube_pos"])}
+        info = {"is_success": self.is_success(ee_pos, cube_pos)}
 
         terminated = info["is_success"]
         truncated = False
-        reward = self.compute_reward(ee_pos, observation["cube_pos"])
+        reward = self.compute_reward(ee_pos, cube_pos)
         return observation, reward, terminated, truncated, info
 
     def goal_distance(self, goal_a, goal_b):

--- a/gym_lowcostrobot/envs/stack_two_cubes_env.py
+++ b/gym_lowcostrobot/envs/stack_two_cubes_env.py
@@ -330,14 +330,21 @@ class StackTwoCubesEnv(Env):
         # Get the new observation
         observation = self.get_observation()
 
-        # The target position is the position of the red cube plus translated in the z-axis by the height of the red cube
-        target_pos = observation["cube_red_pos"] + np.array([0.0, 0.0, 0.03])
+        # Get the position of the blue cube and the red cube
+        cube_blue_id = self.model.body("cube_blue").id
+        cube_blue_pos = self.data.body(cube_blue_id).xpos.copy()
 
-        info = {"is_success": self.is_success(observation["cube_blue_pos"], target_pos)}
+        cube_red_id = self.model.body("cube_red").id
+        cube_red_pos = self.data.body(cube_red_id).xpos.copy()
+
+        # The target position is the position of the red cube plus translated in the z-axis by the height of the red cube
+        target_pos = cube_red_pos + np.array([0.0, 0.0, 0.03])
+
+        info = {"is_success": self.is_success(cube_blue_pos, target_pos)}
 
         terminated = info["is_success"]
         truncated = False
-        reward = self.compute_reward(observation["cube_blue_pos"], target_pos)
+        reward = self.compute_reward(cube_blue_pos, target_pos)
         return observation, reward, terminated, truncated, info
 
     def goal_distance(self, goal_a, goal_b):

--- a/gym_lowcostrobot/envs/stack_two_cubes_env.py
+++ b/gym_lowcostrobot/envs/stack_two_cubes_env.py
@@ -92,7 +92,9 @@ class StackTwoCubesEnv(Env):
 
         # Set the action space
         self.action_mode = action_mode
-        action_shape = {"joint": 6, "ee": 4}[action_mode]
+        self.block_gripper = block_gripper
+        action_shape = {"joint": 6, "ee": 3}[self.action_mode]
+        action_shape += 0 if self.block_gripper and self.action_mode == "ee" else 1
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(action_shape,), dtype=np.float32)
 
         self.num_dof = 6

--- a/gym_lowcostrobot/envs/stack_two_cubes_env.py
+++ b/gym_lowcostrobot/envs/stack_two_cubes_env.py
@@ -94,7 +94,7 @@ class StackTwoCubesEnv(Env):
         self.action_mode = action_mode
         action_shape = {"joint": 6, "ee": 4}[action_mode]
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(action_shape,), dtype=np.float32)
-        
+
         self.num_dof = 6
         self.distance_threshold = distance_threshold
         self.reward_type = reward_type
@@ -233,7 +233,7 @@ class StackTwoCubesEnv(Env):
         """
         if np.array(action).shape != self.action_space.shape:
             raise ValueError("Action dimension mismatch")
-        
+
         action = np.clip(action, self.action_space.low, self.action_space.high)
 
         if self.action_mode == "ee":
@@ -246,11 +246,13 @@ class StackTwoCubesEnv(Env):
 
             # Use inverse kinematics to get the joint action wrt the end effector current position and displacement
             target_qpos = self.inverse_kinematics(ee_target_pos=ee_target_pos)
-            
-            #Update the robot gripper position based on the action 
+
+            # Update the robot gripper position based on the action
             target_gripper_pos = gripper_action * 0.2
-            current_gripper_joint_angle = self.data.qpos[self.num_dof-1].copy()
-            target_qpos[-1:] = np.clip(current_gripper_joint_angle + target_gripper_pos, self.ctrl_range[-1, 0], self.ctrl_range[-1, 1])
+            current_gripper_joint_angle = self.data.qpos[self.num_dof - 1].copy()
+            target_qpos[-1:] = np.clip(
+                current_gripper_joint_angle + target_gripper_pos, self.ctrl_range[-1, 0], self.ctrl_range[-1, 1]
+            )
         elif self.action_mode == "joint":
             target_low = np.array([-3.14159, -1.5708, -1.48353, -1.91986, -2.96706, -1.74533])
             target_high = np.array([3.14159, 1.22173, 1.74533, 1.91986, 2.96706, 0.0523599])
@@ -295,13 +297,13 @@ class StackTwoCubesEnv(Env):
         cube_blue_pos = self.np_random.uniform(self.cube_low, self.cube_high)
         cube_blue_rot = np.array([1.0, 0.0, 0.0, 0.0])
         robot_qpos = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-        self.data.qpos[: self.num_dof] = robot_qpos 
+        self.data.qpos[: self.num_dof] = robot_qpos
         self.data.qpos[self.num_dof : self.num_dof + 7] = np.concatenate([cube_red_pos, cube_red_rot])
         self.data.qpos[self.num_dof + 7 : self.num_dof + 14] = np.concatenate([cube_blue_pos, cube_blue_rot])
 
         # Step the simulation
-        mujoco.mj_forward(self.model, self.data)   
-        
+        mujoco.mj_forward(self.model, self.data)
+
         return self.get_observation(), {}
 
     def step(self, action):

--- a/gym_lowcostrobot/envs/stack_two_cubes_env.py
+++ b/gym_lowcostrobot/envs/stack_two_cubes_env.py
@@ -93,8 +93,8 @@ class StackTwoCubesEnv(Env):
         # Set the action space
         self.action_mode = action_mode
         self.block_gripper = block_gripper
-        action_shape = {"joint": 6, "ee": 3}[self.action_mode]
-        action_shape += 0 if self.block_gripper and self.action_mode == "ee" else 1
+        action_shape = {"joint": 5, "ee": 3}[self.action_mode]
+        action_shape += 0 if self.block_gripper else 1
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(action_shape,), dtype=np.float32)
 
         self.num_dof = 6
@@ -258,8 +258,23 @@ class StackTwoCubesEnv(Env):
         elif self.action_mode == "joint":
             target_low = np.array([-3.14159, -1.5708, -1.48353, -1.91986, -2.96706, -1.74533])
             target_high = np.array([3.14159, 1.22173, 1.74533, 1.91986, 2.96706, 0.0523599])
-            current_arm_joint_angles = self.data.qpos[: self.num_dof].copy()
-            target_qpos = np.array(action).clip(target_low, target_high) + current_arm_joint_angles
+            # Separate arm joint angles and gripper position
+            current_joint_angles = self.data.qpos[: self.num_dof].copy()
+            arm_action = np.array(action[: self.num_dof - 1])
+            gripper_action = action[-1]
+
+            # Clip and update arm joint positions
+            target_arm_qpos = np.clip(
+                arm_action + current_joint_angles[: self.num_dof - 1],
+                target_low[: self.num_dof - 1],
+                target_high[: self.num_dof - 1],
+            )
+
+            # Clip and update gripper position
+            target_gripper_pos = np.clip(gripper_action + current_joint_angles[-1], target_low[-1], target_high[-1])
+
+            # Combine arm and gripper targets
+            target_qpos = np.append(target_arm_qpos, target_gripper_pos)
         else:
             raise ValueError("Invalid action mode, must be 'ee' or 'joint'")
 

--- a/gym_lowcostrobot/envs/stack_two_cubes_env.py
+++ b/gym_lowcostrobot/envs/stack_two_cubes_env.py
@@ -80,7 +80,7 @@ class StackTwoCubesEnv(Env):
         observation_mode="image",
         action_mode="joint",
         reward_type="sparse",
-        block_gripper=True,
+        block_gripper=False,
         distance_threshold=0.05,
         cube_xy_range=0.3,
         n_substeps=20,

--- a/gym_lowcostrobot/envs/stack_two_cubes_env.py
+++ b/gym_lowcostrobot/envs/stack_two_cubes_env.py
@@ -6,7 +6,7 @@ import mujoco.viewer
 import numpy as np
 from gymnasium import Env, spaces
 
-from gym_lowcostrobot import ASSETS_PATH, BASE_LINK_NAME
+from gym_lowcostrobot import ASSETS_PATH
 
 
 class StackTwoCubesEnv(Env):
@@ -73,11 +73,21 @@ class StackTwoCubesEnv(Env):
     - `render_mode (str)`: the render mode, can be "human" or "rgb_array", default is None.
     """
 
-    metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 200}
+    metadata = {"render_modes": ["human", "rgb_array"], "render_fps": 25}
 
-    def __init__(self, observation_mode="image", action_mode="joint", render_mode=None):
+    def __init__(
+        self,
+        observation_mode="image",
+        action_mode="joint",
+        reward_type="sparse",
+        block_gripper=True,
+        distance_threshold=0.05,
+        cube_xy_range=0.3,
+        n_substeps=20,
+        render_mode=None,
+    ):
         # Load the MuJoCo model and data
-        self.model = mujoco.MjModel.from_xml_path(os.path.join(ASSETS_PATH, "stack_two_cubes.xml"), {})
+        self.model = mujoco.MjModel.from_xml_path(os.path.join(ASSETS_PATH, "stack_two_cubes.xml"))
         self.data = mujoco.MjData(self.model)
 
         # Set the action space
@@ -85,7 +95,9 @@ class StackTwoCubesEnv(Env):
         action_shape = {"joint": 6, "ee": 4}[action_mode]
         self.action_space = spaces.Box(low=-1.0, high=1.0, shape=(action_shape,), dtype=np.float32)
         
-        self.nb_dof = 6
+        self.num_dof = 6
+        self.distance_threshold = distance_threshold
+        self.reward_type = reward_type
 
         # Set the observations space
         self.observation_mode = observation_mode
@@ -102,79 +114,113 @@ class StackTwoCubesEnv(Env):
             observation_subspaces["cube_blue_pos"] = spaces.Box(low=-10.0, high=10.0, shape=(3,))
         self.observation_space = gym.spaces.Dict(observation_subspaces)
 
+        self.control_decimation = n_substeps  # number of simulation steps per control step
+
         # Set the render utilities
         assert render_mode is None or render_mode in self.metadata["render_modes"]
         self.render_mode = render_mode
         if self.render_mode == "human":
-            self.viewer = mujoco.viewer.launch_passive(self.model, self.data)
-            self.viewer.cam.azimuth = -75
-            self.viewer.cam.distance = 1
+            self.viewer = mujoco.viewer.launch_passive(self.model, self.data, show_left_ui=False, show_right_ui=False)
+            self.viewer.cam.azimuth = -45.0
+            self.viewer.cam.distance = 1.5
+            self.viewer.cam.elevation = -20.0
+            self.viewer.cam.lookat = np.array([0.0, 0.0, 0.0])
         elif self.render_mode == "rgb_array":
             self.rgb_array_renderer = mujoco.Renderer(self.model, height=640, width=640)
 
         # Set additional utils
-        self.threshold_height = 0.5
-        self.cube_low = np.array([-0.15, 0.10, 0.015])
-        self.cube_high = np.array([0.15, 0.25, 0.015])
+        self.cube_xy_range = cube_xy_range
 
-        # get dof addresses
-        self.red_cube_dof_id = self.model.body("cube_red").dofadr[0]
-        self.blue_cube_dof_id = self.model.body("cube_blue").dofadr[0] + 1
-        self.arm_dof_id = self.model.body(BASE_LINK_NAME).dofadr[0]
-        self.arm_dof_vel_id = self.arm_dof_id
-        # if the arm is not at address 0 then the both cubes will have 7 states in qpos and 6 in qvel each
-        if self.arm_dof_id != 0:
-            self.arm_dof_id = self.arm_dof_vel_id + 2
-            
-        self.control_decimation = 4 # number of simulation steps per control step
+        self.cube_low = np.array([-self.cube_xy_range / 2, -self.cube_xy_range / 2, 0])
+        self.cube_high = np.array([self.cube_xy_range / 2, self.cube_xy_range / 2, 0])
 
-    def inverse_kinematics(self, ee_target_pos, step=0.2, joint_name="link_6", nb_dof=6, regularization=1e-6):
+        # Shift in y-axis to sample from positive coordinates in the y-axis
+        self.cube_low[1] += 0.165
+        self.cube_high[1] += 0.10
+
+        # control range
+        self.ctrl_range = self.model.actuator_ctrlrange
+
+    def check_joint_limits(self, q):
+        """Check if the joints is under or above its limits"""
+        for i in range(len(q)):
+            q[i] = max(self.model.jnt_range[i][0], min(q[i], self.model.jnt_range[i][1]))
+
+        return q
+
+    def inverse_kinematics(
+        self,
+        ee_target_pos,
+        ee_site="end_effector_site",
+        num_dof=6,
+        step=0.5,
+        lm_damping=0.15,
+        max_iter=10,
+        tolerance_err=0.01,
+        home_position=None,
+        nullspace_weight=0.0,
+    ):
         """
         Computes the inverse kinematics for a robotic arm to reach the target end effector position.
 
         :param ee_target_pos: numpy array of target end effector position [x, y, z]
+        :param ee_site: str, name of the end effector site
+        :param num_dof: int, number of degrees of freedom
         :param step: float, step size for the iteration
-        :param joint_name: str, name of the end effector joint
-        :param nb_dof: int, number of degrees of freedom
-        :param regularization: float, regularization factor for the pseudoinverse computation
+        :param lm_damping: float, regularization factor for the pseudoinverse computation
+        :param max_iter: int, maximum number of iterations
+        :param tolerance_err: float, tolerance error
+        :param home_position: numpy array of home joint positions to regularize towards
+        :param nullspace_weight: float, weight for the nullspace regularization
         :return: numpy array of target joint positions
         """
-        try:
-            # Get the joint ID from the name
-            joint_id = self.model.body(joint_name).id
-        except KeyError:
-            raise ValueError(f"Body name '{joint_name}' not found in the model.")
 
-        # Get the current end effector position
-        # ee_pos = self.d.geom_xpos[joint_id]
-        ee_id = self.model.body(joint_name).id
-        ee_pos = self.data.geom_xpos[ee_id]
+        if home_position is None:
+            home_position = np.zeros(num_dof)  # Default to zero if no home position is provided
 
-        # Compute the Jacobian
-        jac = np.zeros((3, self.model.nv))
-        mujoco.mj_jacBodyCom(self.model, self.data, jac, None, joint_id)
+        jacp = np.zeros((3, self.model.nv))
+        ee_id = self.model.site(ee_site).id
 
-        # Compute the difference between target and current end effector positions
-        delta_pos = ee_target_pos - ee_pos
+        # Initial joint positions
+        q = self.data.qpos[:num_dof].copy()
 
-        # Compute the pseudoinverse of the Jacobian with regularization
-        jac_reg = jac[:, :nb_dof].T @ jac[:, :nb_dof] + regularization * np.eye(nb_dof)
-        jac_pinv = np.linalg.inv(jac_reg) @ jac[:, :nb_dof].T
+        for _ in range(max_iter):
+            self.data.qpos[:num_dof] = q
+            mujoco.mj_forward(self.model, self.data)
 
-        # Compute target joint velocities
-        qdot = jac_pinv @ delta_pos
+            ee_pos = self.data.site(ee_id).xpos
+            error = ee_target_pos - ee_pos
+            error_norm = np.linalg.norm(error)
 
-        # Normalize joint velocities to avoid excessive movements
-        qdot_norm = np.linalg.norm(qdot)
-        if qdot_norm > 1.0:
-            qdot /= qdot_norm
+            # Stop iterations
+            if error_norm < tolerance_err:
+                break
 
-        # Read the current joint positions
-        qpos = self.data.qpos[self.arm_dof_id:self.arm_dof_id+nb_dof]
+            # Jacobian
+            mujoco.mj_jacSite(self.model, self.data, jacp, None, ee_id)
 
-        # Compute the new joint positions
-        q_target_pos = qpos + qdot * step
+            # Damped least squares (Levenberg-Marquardt Algorithm)
+            jac_reg = jacp[:, :num_dof].T @ jacp[:, :num_dof] + lm_damping * np.eye(num_dof)
+            jac_pinv = np.linalg.inv(jac_reg) @ jacp[:, :num_dof].T
+            qdot = jac_pinv @ error
 
+            # Nullspace control biasing joint velocities towards the home configuration
+            qdot += (np.eye(num_dof) - np.linalg.pinv(jacp[:, :num_dof]) @ jacp[:, :num_dof]) @ (
+                nullspace_weight * (home_position - self.data.qpos[:num_dof])
+            )
+
+            # Normalize joint velocity
+            qdot_norm = np.linalg.norm(qdot)
+            if qdot_norm > 1.0:
+                qdot /= qdot_norm
+
+            # Compute the new joint positions. Integrate joint velocities to obtain joint positions.
+            q += qdot * step
+
+            # Check limits
+            q = self.check_joint_limits(q)
+
+        q_target_pos = q
         return q_target_pos
 
     def apply_action(self, action):
@@ -183,23 +229,33 @@ class StackTwoCubesEnv(Env):
 
         Action shape
         - EE mode: [dx, dy, dz, gripper]
-        - Joint mode: [q1, q2, q3, q4, q5, q6, gripper]
+        - Joint mode: [q1, q2, q3, q4, q5, gripper]
         """
+        if np.array(action).shape != self.action_space.shape:
+            raise ValueError("Action dimension mismatch")
+        
+        action = np.clip(action, self.action_space.low, self.action_space.high)
+
         if self.action_mode == "ee":
-            # raise NotImplementedError("EE mode not implemented yet")
-            ee_action, gripper_action = action[:3], action[-1]
+            ee_action, gripper_action = action[:3], action[3]
 
             # Update the robot position based on the action
-            ee_id = self.model.body("link_6").id
-            ee_target_pos = self.data.xpos[ee_id] + ee_action
+            ee_id = self.model.site("end_effector_site").id
+            ee_target_pos = self.data.site(ee_id).xpos + ee_action * 0.05  # limit maximum change in position
+            ee_target_pos[2] = np.max((0, ee_target_pos[2]))
 
             # Use inverse kinematics to get the joint action wrt the end effector current position and displacement
             target_qpos = self.inverse_kinematics(ee_target_pos=ee_target_pos)
-            target_qpos[-1:] = gripper_action
+            
+            #Update the robot gripper position based on the action 
+            target_gripper_pos = gripper_action * 0.2
+            current_gripper_joint_angle = self.data.qpos[self.num_dof-1].copy()
+            target_qpos[-1:] = np.clip(current_gripper_joint_angle + target_gripper_pos, self.ctrl_range[-1, 0], self.ctrl_range[-1, 1])
         elif self.action_mode == "joint":
             target_low = np.array([-3.14159, -1.5708, -1.48353, -1.91986, -2.96706, -1.74533])
             target_high = np.array([3.14159, 1.22173, 1.74533, 1.91986, 2.96706, 0.0523599])
-            target_qpos = np.array(action).clip(target_low, target_high)
+            current_arm_joint_angles = self.data.qpos[: self.num_dof].copy()
+            target_qpos = np.array(action).clip(target_low, target_high) + current_arm_joint_angles
         else:
             raise ValueError("Invalid action mode, must be 'ee' or 'joint'")
 
@@ -213,20 +269,20 @@ class StackTwoCubesEnv(Env):
                 self.viewer.sync()
 
     def get_observation(self):
-        # qpos is [xr, yr, zr, qwr, qxr, qyr, qzr, xb, yb, zb, qwb, qxb, qyb, qzb, q1, q2, q3, q4, q5, q6, gripper]
-        # qvel is [vxr, vyr, vzr, wxr, wyr, wzr, vxb, vyb, vzb, wxb, wyb, wzb, dq1, dq2, dq3, dq4, dq5, dq6, dgripper]
+        # qpos is [xr, yr, zr, qwr, qxr, qyr, qzr, xb, yb, zb, qwb, qxb, qyb, qzb, q1, q2, q3, q4, q5, gripper]
+        # qvel is [vxr, vyr, vzr, wxr, wyr, wzr, vxb, vyb, vzb, wxb, wyb, wzb, dq1, dq2, dq3, dq4, dq5, dgripper]
         observation = {
-            "arm_qpos": self.data.qpos[self.arm_dof_id+self.arm_dof_id+self.nb_dof].astype(np.float32),
-            "arm_qvel": self.data.qvel[self.arm_dof_vel_id:self.arm_dof_vel_id+self.nb_dof].astype(np.float32),
+            "arm_qpos": self.data.qpos[: self.num_dof].astype(np.float32),
+            "arm_qvel": self.data.qvel[: self.num_dof].astype(np.float32),
         }
-        if self.observation_mode in ["state", "both"]:
-            observation["cube_red_pos"] = self.data.qpos[self.red_cube_dof_id:self.red_cube_dof_id+3].astype(np.float32)
-            observation["cube_blue_pos"] = self.data.qpos[self.blue_cube_dof_id:self.blue_cube_dof_id+3].astype(np.float32)
         if self.observation_mode in ["image", "both"]:
             self.renderer.update_scene(self.data, camera="camera_front")
             observation["image_front"] = self.renderer.render()
             self.renderer.update_scene(self.data, camera="camera_top")
             observation["image_top"] = self.renderer.render()
+        if self.observation_mode in ["state", "both"]:
+            observation["cube_red_pos"] = self.data.qpos[self.num_dof : self.num_dof + 3].astype(np.float32).copy()
+            observation["cube_blue_pos"] = self.data.qpos[self.num_dof + 7 : self.num_dof + 10].astype(np.float32).copy()
         return observation
 
     def reset(self, seed=None, options=None):
@@ -239,9 +295,9 @@ class StackTwoCubesEnv(Env):
         cube_blue_pos = self.np_random.uniform(self.cube_low, self.cube_high)
         cube_blue_rot = np.array([1.0, 0.0, 0.0, 0.0])
         robot_qpos = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-        self.data.qpos[self.arm_dof_id:self.arm_dof_id+self.nb_dof] = robot_qpos 
-        self.data.qpos[self.red_cube_dof_id:self.red_cube_dof_id+7] = np.concatenate([cube_red_pos, cube_red_rot])
-        self.data.qpos[self.blue_cube_dof_id:self.blue_cube_dof_id+7] = np.concatenate([cube_blue_pos, cube_blue_rot])
+        self.data.qpos[: self.num_dof] = robot_qpos 
+        self.data.qpos[self.num_dof : self.num_dof + 7] = np.concatenate([cube_red_pos, cube_red_rot])
+        self.data.qpos[self.num_dof + 7 : self.num_dof + 14] = np.concatenate([cube_blue_pos, cube_blue_rot])
 
         # Step the simulation
         mujoco.mj_forward(self.model, self.data)   
@@ -255,15 +311,30 @@ class StackTwoCubesEnv(Env):
         # Get the new observation
         observation = self.get_observation()
 
-        # Get the position of the cube and the distance between the end effector and the cube
-        cube_red_pos = self.data.qpos[self.red_cube_dof_id:self.red_cube_dof_id+3]
-        cube_blue_pos = self.data.qpos[self.blue_cube_dof_id:self.blue_cube_dof_id+3]
-        target_pos = cube_red_pos + np.array([0.0, 0.0, 0.03])
-        cube_blue_to_target = np.linalg.norm(cube_blue_pos - target_pos)
+        # The target position is the position of the red cube plus translated in the z-axis by the height of the red cube
+        target_pos = observation["cube_red_pos"] + np.array([0.0, 0.0, 0.03])
 
-        # Compute the reward
-        reward = -cube_blue_to_target
-        return observation, reward, False, False, {}
+        info = {"is_success": self.is_success(observation["cube_blue_pos"], target_pos)}
+
+        terminated = info["is_success"]
+        truncated = False
+        reward = self.compute_reward(observation["cube_blue_pos"], target_pos)
+        return observation, reward, terminated, truncated, info
+
+    def goal_distance(self, goal_a, goal_b):
+        assert goal_a.shape == goal_b.shape
+        return np.linalg.norm(goal_a - goal_b)
+
+    def is_success(self, achieved_goal, desired_goal):
+        d = self.goal_distance(achieved_goal, desired_goal)
+        return d < self.distance_threshold
+
+    def compute_reward(self, achieved_goal, desired_goal):
+        d = self.goal_distance(achieved_goal, desired_goal)
+        if self.reward_type == "sparse":
+            return -(d > self.distance_threshold).astype(np.float32)
+        else:
+            return -d
 
     def render(self):
         if self.render_mode == "human":

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -5,7 +5,7 @@ from gymnasium.utils.env_checker import check_env
 import gym_lowcostrobot  # noqa
 
 
-@pytest.mark.parametrize("env_id", ["LiftCube-v0", "PickPlaceCube-v0", "PushCube-v0", "ReachCube-v0", "StackTwoCubes-v0"])
+@pytest.mark.parametrize("env_id", ["LiftCube-v0", "PickPlaceCube-v0", "PushCube-v0", "ReachCube-v0", "StackTwoCubes-v0", "PushCubeLoop-v0"])
 @pytest.mark.parametrize("observation_mode", ["state", "image"])
 def test_env_check(env_id, observation_mode):
     env = gym.make(env_id, observation_mode=observation_mode)


### PR DESCRIPTION
This PR introduces several updates and improvements to the environments as part of a broader effort to enhance and standardize the `gym_lowcostrobot` repository. Below is a detailed list of the changes made:  

#### General Changes  
- **Imports**: Removed the `baselink` constant from imports.  
- **Docstring**: Updated the reward function description for clarity.  

#### MJCF
- **Timestep**: changed the `timestep` to 0.002s.
- **Convexhull**: removed the `convexhull` from pick and place cube env.

#### Environment Parameters  
- **Render FPS**: Adjusted `render_fps` to 25Hz, calculated as `1 / (timestep × num_substeps) = 1 / (0.002 × 20)`.  
- **Action Space**: Added an option to block the gripper and adjusted the action space accordingly.  
- **Added Parameters**:  
  - `distance_threshold`  
  - `reward_type`  
  - `num_dof` (replacing `nb_dof` better naming)  
- **Substeps**: Changed `num_substeps` to 20, aligning with the PandaGym paper by Quentin Gallouedec.  

#### Simulation Enhancements  
- **Camera View**: Updated viewer settings to provide a clearer view of the robot arm.  
- **Cube Sampling**: Updated the cube's sampling range on the XY plane and shifted the Y-axis sampling to positive coordinates.  
- **Joint Limits**: Added a function to check for joint limits.  

#### Updates to Core Functions  
- **Inverse Kinematics (IK)**:  
  - Changed to use the `"end_effector_site"` (also updated in MJCF).  
  - Introduced `max_iter` (maximum iterations for the LM algorithm) and tolerance error to terminate iterations.  
  - Corrected nullspace projection logic.  
  - Integrated joint limit checks.  

- **`apply_action`**:  
  - Validated input action dimensions and clamped actions.  
  - Limited the maximum action change (scaled by 0.05).  
  - Clamped negative Z-axis values to prevent the arm from passing through the floor.  
  - Added gripper-blocking logic and adjusted the action handling logic for "joint" mode.  

- **`get_observation`**:  
  - Removed unnecessary logic for cube and robot address retrieval (handled by Mujoco's sorting in MJCF).  
  - Updated comments to align with 6 DOF configurations (removed references to `q6` and `dq6`).  

- **`step`**:  
  - Accessed cube and end-effector positions by name for improved accuracy.  
  - Added helper functions for calculating distances, rewards, and success checks. This approach aids in debugging and logging within the `info` dictionary.  
